### PR TITLE
feat: merge external ontologies and expose prefixes

### DIFF
--- a/ontology_guided/llm_interface.py
+++ b/ontology_guided/llm_interface.py
@@ -1,6 +1,6 @@
 import openai
 import httpx
-from typing import List
+from typing import List, Tuple, Optional
 import re
 import time
 
@@ -14,16 +14,24 @@ class LLMInterface:
         sentences: List[str],
         prompt_template: str,
         *,
+        available_terms: Optional[Tuple[List[str], List[str]]] = None,
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> List[str]:
         """Call the LLM and return only the Turtle code."""
         results = []
+        classes = properties = []
+        if available_terms:
+            classes, properties = available_terms
         for sent in sentences:
-            prompt = (
-                "Return ONLY valid Turtle code, without any explanatory text or markdown fences."
-                + "\n" + prompt_template.format(sentence=sent)
-            )
+            prompt = "Return ONLY valid Turtle code, without any explanatory text or markdown fences.\n"
+            if classes or properties:
+                prompt += "Use existing ontology terms when appropriate.\n"
+                if classes:
+                    prompt += "Classes: " + ", ".join(classes) + "\n"
+                if properties:
+                    prompt += "Properties: " + ", ".join(properties) + "\n"
+            prompt += prompt_template.format(sentence=sent)
             attempts = 0
             resp = None
             while True:

--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -1,21 +1,51 @@
 from rdflib import Graph
+from rdflib.namespace import RDF, RDFS, OWL, XSD
 
 
 class OntologyBuilder:
     """Μετατρέπει τμήματα Turtle σε ενιαία οντολογία."""
 
-    def __init__(self, base_iri: str):
+    def __init__(self, base_iri: str, ontology_files=None):
         if not base_iri.endswith("#"):
             base_iri += "#"
         self.base_iri = base_iri
-        self.header = (
-            f"@prefix atm: <{self.base_iri}> .\n"
-            "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n"
-            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
-            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n"
-            "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
-        )
         self.graph = Graph()
+        self.graph.bind("atm", self.base_iri)
+        if ontology_files:
+            for path in ontology_files:
+                self.graph.parse(path)
+        self._build_header()
+        self._extract_available_terms()
+
+    def _build_header(self):
+        prefixes = {
+            "atm": self.base_iri,
+            "rdf": str(RDF),
+            "rdfs": str(RDFS),
+            "owl": str(OWL),
+            "xsd": str(XSD),
+        }
+        for prefix, uri in self.graph.namespaces():
+            if prefix and prefix not in prefixes:
+                prefixes[prefix] = str(uri)
+        self.header = "".join(
+            f"@prefix {p}: <{u}> .\n" for p, u in prefixes.items()
+        )
+
+    def _extract_available_terms(self):
+        nm = self.graph.namespace_manager
+        classes = [
+            nm.normalizeUri(c)
+            for c in self.graph.subjects(RDF.type, OWL.Class)
+        ]
+        props = []
+        for t in (OWL.ObjectProperty, OWL.DatatypeProperty, OWL.AnnotationProperty):
+            props.extend(nm.normalizeUri(p) for p in self.graph.subjects(RDF.type, t))
+        self.available_classes = sorted(set(classes))
+        self.available_properties = sorted(set(props))
+
+    def get_available_terms(self):
+        return self.available_classes, self.available_properties
 
     def parse_turtle(self, turtle_str: str):
         lines = [line for line in turtle_str.splitlines() if line.strip()]
@@ -25,6 +55,7 @@ class OntologyBuilder:
         print(data)
         print("=== End of Turtle ===")
         self.graph.parse(data=data, format="turtle")
+        self._extract_available_terms()
 
     def save(self, file_path: str, fmt: str = "turtle"):
         """Αποθηκεύει την οντολογία σε αρχείο."""

--- a/tests/test_ontology_builder.py
+++ b/tests/test_ontology_builder.py
@@ -6,3 +6,18 @@ def test_parse_turtle_with_prefix():
     ttl = """@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."""
     ob.parse_turtle(ttl)
     assert len(ob.graph) == 1
+
+
+def test_import_external_ontology(tmp_path):
+    ext = tmp_path / "ext.ttl"
+    ext.write_text(
+        """@prefix ex: <http://example.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+ex:ClassA a owl:Class .
+""",
+        encoding="utf-8",
+    )
+    ob = OntologyBuilder('http://example.com/atm#', [str(ext)])
+    classes, _ = ob.get_available_terms()
+    assert "ex:ClassA" in classes
+    assert "@prefix ex:" in ob.header


### PR DESCRIPTION
## Summary
- allow `OntologyBuilder` to import external ontologies, gather prefixes and available terms
- include existing ontology terms in LLM prompts
- accept ontology files through CLI and web UI before parsing LLM output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dc0914c4883308e7d26930f6598c9