### PR TITLE
Enforce typed actors and targets in SHACL shapes

### DIFF
--- a/demo.txt
+++ b/demo.txt
@@ -1,1 +1,28 @@
-The ATM must log all user transactions after card insertion, linking each transaction to the user who performed it.
+@prefix atm: <http://example.com/atm#> .
+
+atm:alice a atm:User .
+atm:acc123 a atm:Account .
+atm:tx1 a atm:Transaction ;
+    atm:actor atm:alice ;
+    atm:target atm:acc123 .
+
+atm:device1 a atm:Device .
+atm:tx2 a atm:Transaction ;
+    atm:actor atm:device1 ;
+    atm:target atm:acc123 .
+
+atm:cash a atm:Item .
+atm:cashWithdrawal a atm:Action ;
+    atm:actor atm:alice ;
+    atm:object atm:cash .
+
+atm:balanceInquiry a atm:Action ;
+    atm:actor atm:alice ;
+    atm:object atm:unknownObject .
+
+atm:insert1 a atm:CardInsertion ;
+    atm:after atm:tx1 .
+
+atm:insert2 a atm:CardInsertion ;
+    atm:after atm:device1 .
+

--- a/shapes.ttl
+++ b/shapes.ttl
@@ -9,10 +9,12 @@ atm:TransactionShape
     sh:property [
         sh:path atm:actor ;
         sh:minCount 1 ;
+        sh:class atm:User ;
     ] ;
     sh:property [
         sh:path atm:target ;
         sh:minCount 1 ;
+        sh:class atm:Account ;
     ] .
 
 # Κάθε ενέργεια πρέπει επίσης να ορίζει actor και object
@@ -22,10 +24,12 @@ atm:ActionShape
     sh:property [
         sh:path atm:actor ;
         sh:minCount 1 ;
+        sh:class atm:User ;
     ] ;
     sh:property [
         sh:path atm:object ;
         sh:minCount 1 ;
+        sh:class atm:Item ;
     ] .
 
 # Εισαγωγή κάρτας πρέπει να συσχετίζεται με συναλλαγή
@@ -35,5 +39,6 @@ atm:CardInsertionShape
     sh:property [
         sh:path atm:after ;
         sh:minCount 1 ;
+        sh:class atm:Transaction ;
     ] .
     

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -9,5 +9,16 @@ def test_demo_txt_loading_and_preprocessing():
     for t in texts:
         sentences.extend(loader.preprocess_text(t))
     assert sentences == [
-        "The ATM must log all user transactions after card insertion, linking each transaction to the user who performed it."
+        "@prefix atm: <http://example.com/atm#> .",
+        "atm:alice a atm:User .",
+        "atm:acc123 a atm:Account .",
+        "atm:tx1 a atm:Transaction ; atm:actor atm:alice ; atm:target atm:acc123 .",
+        "atm:device1 a atm:Device .",
+        "atm:tx2 a atm:Transaction ; atm:actor atm:device1 ; atm:target atm:acc123 .",
+        "atm:cash a atm:Item .",
+        "atm:cashWithdrawal a atm:Action ; atm:actor atm:alice ; atm:object atm:cash .",
+        "atm:balanceInquiry a atm:Action ; atm:actor atm:alice ; atm:object atm:unknownObject .",
+        "atm:insert1 a atm:CardInsertion ; atm:after atm:tx1 .",
+        "atm:insert2 a atm:CardInsertion ; atm:after atm:device1 .",
     ]
+

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from ontology_guided.validator import SHACLValidator
+
+
+def _write_temp(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+def test_validation_conforming(tmp_path):
+    data = """@prefix atm: <http://example.com/atm#> .
+
+atm:alice a atm:User .
+atm:acc123 a atm:Account .
+atm:tx1 a atm:Transaction ;
+    atm:actor atm:alice ;
+    atm:target atm:acc123 .
+
+atm:cash a atm:Item .
+atm:act1 a atm:Action ;
+    atm:actor atm:alice ;
+    atm:object atm:cash .
+
+atm:insert1 a atm:CardInsertion ;
+    atm:after atm:tx1 .
+"""
+    data_path = _write_temp(tmp_path, "valid.ttl", data)
+    shapes_path = Path(__file__).resolve().parent.parent / "shapes.ttl"
+    validator = SHACLValidator(data_path, str(shapes_path))
+    conforms, _, _ = validator.run_validation()
+    assert conforms
+
+
+def test_validation_non_conforming(tmp_path):
+    data = """@prefix atm: <http://example.com/atm#> .
+
+atm:device1 a atm:Device .
+atm:acc123 a atm:Account .
+atm:tx2 a atm:Transaction ;
+    atm:actor atm:device1 ;
+    atm:target atm:acc123 .
+"""
+    data_path = _write_temp(tmp_path, "invalid.ttl", data)
+    shapes_path = Path(__file__).resolve().parent.parent / "shapes.ttl"
+    validator = SHACLValidator(data_path, str(shapes_path))
+    conforms, _, _ = validator.run_validation()
+    assert not conforms
+


### PR DESCRIPTION
## Summary
- Require `atm:actor` of `atm:Transaction` and `atm:Action` to be an `atm:User` and ensure `atm:target` or `atm:object` have appropriate classes
- Add sample ATM triples to `demo.txt`
- Introduce SHACL validator tests for both conforming and invalid data and update loader test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dc33cba2083309911d346d18719b3