### PR TITLE
Enable logging in parse_turtle

### DIFF
--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -1,3 +1,5 @@
+import logging
+
 from rdflib import Graph
 from rdflib.namespace import RDF, RDFS, OWL, XSD
 
@@ -47,13 +49,14 @@ class OntologyBuilder:
     def get_available_terms(self):
         return self.available_classes, self.available_properties
 
-    def parse_turtle(self, turtle_str: str):
+    def parse_turtle(self, turtle_str: str, logger: logging.Logger | None = None):
         lines = [line for line in turtle_str.splitlines() if line.strip()]
         cleaned = "\n".join(lines)
         data = self.header + "\n" + cleaned
-        print("=== Turtle input to rdflib.parse ===")
-        print(data)
-        print("=== End of Turtle ===")
+        if logger:
+            logger.debug("=== Turtle input to rdflib.parse ===")
+            logger.debug(data)
+            logger.debug("=== End of Turtle ===")
         self.graph.parse(data=data, format="turtle")
         self._extract_available_terms()
 
@@ -65,12 +68,14 @@ class OntologyBuilder:
 if __name__ == "__main__":
     import os
 
+    logging.basicConfig(level=logging.DEBUG)
     BASE_IRI = "http://example.com/atm#"
     os.makedirs("results", exist_ok=True)
     with open("results/llm_output.ttl", "r", encoding="utf-8") as f:
         ttl = f.read()
     ob = OntologyBuilder(BASE_IRI)
-    ob.parse_turtle(ttl)
+    logger = logging.getLogger(__name__)
+    ob.parse_turtle(ttl, logger=logger)
     ob.save("results/combined.ttl", fmt="turtle")
     ob.save("results/combined.owl", fmt="xml")
     print("Saved results/combined.ttl and results/combined.owl")

--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from dotenv import load_dotenv
 
 from .validator import SHACLValidator
@@ -36,7 +37,8 @@ class RepairLoop:
         with open(self.data_path, "r", encoding="utf-8") as f:
             original = f.read()
         merged = original + "\n\n" + repair_triples
-        self.builder.parse_turtle(merged)
+        logger = logging.getLogger(__name__)
+        self.builder.parse_turtle(merged, logger=logger)
         os.makedirs("results", exist_ok=True)
         self.builder.save("results/repaired.ttl", fmt="turtle")
         self.builder.save("results/repaired.owl", fmt="xml")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from dotenv import load_dotenv
 import sys
+import logging
 
 # Ensure the project root is on the Python path when executed directly
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -45,6 +46,7 @@ def run_pipeline(inputs, shapes, base_iri, ontologies=None, model="gpt-4", repai
     pipeline["sentences"] = sentences
 
     builder = OntologyBuilder(base_iri, ontology_files=ontologies)
+    logger = logging.getLogger(__name__)
     avail_terms = builder.get_available_terms()
 
     llm = LLMInterface(api_key=api_key, model=model)
@@ -53,7 +55,7 @@ def run_pipeline(inputs, shapes, base_iri, ontologies=None, model="gpt-4", repai
 
     os.makedirs("results", exist_ok=True)
     for snippet in owl_snippets:
-        builder.parse_turtle(snippet)
+        builder.parse_turtle(snippet, logger=logger)
     builder.save("results/combined.ttl", fmt="turtle")
     builder.save("results/combined.owl", fmt="xml")
     pipeline["combined_ttl"] = "results/combined.ttl"

--- a/tests/test_ontology_builder.py
+++ b/tests/test_ontology_builder.py
@@ -1,10 +1,13 @@
+import logging
+
 from ontology_guided.ontology_builder import OntologyBuilder
 
 
 def test_parse_turtle_with_prefix():
     ob = OntologyBuilder('http://example.com/atm#')
     ttl = """@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."""
-    ob.parse_turtle(ttl)
+    logger = logging.getLogger(__name__)
+    ob.parse_turtle(ttl, logger=logger)
     assert len(ob.graph) == 1
 
 


### PR DESCRIPTION
## Summary
- switch parse_turtle to use logging instead of direct prints
- allow callers to toggle turtle debug output via optional logger
- update scripts and tests to pass a logger to parse_turtle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689460e7abf883308e5ea2c17cb434ba