### PR TITLE
Separate default class and property lists in LLM interface

### DIFF
--- a/ontology_guided/llm_interface.py
+++ b/ontology_guided/llm_interface.py
@@ -20,7 +20,8 @@ class LLMInterface:
     ) -> List[str]:
         """Call the LLM and return only the Turtle code."""
         results = []
-        classes = properties = []
+        classes = []
+        properties = []
         if available_terms:
             classes, properties = available_terms
         for sent in sentences:


### PR DESCRIPTION
## Summary
- initialize `classes` and `properties` independently in `generate_owl` to avoid shared references

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894630e8dd48330bdf0b1ee711b60b8