### PR TITLE
Add spaCy model and SHACL inference options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Ontology-Guided/
    reasoner και τον έλεγχο SHACL, και αν χρειαστεί εκτελεί αυτόματο βρόχο διόρθωσης.
    Ο φάκελος `results/` δημιουργείται αυτόματα αν δεν υπάρχει.
 
+   Προαιρετικές επιλογές:
+   - `--spacy-model`: ορίζει ποιο spaCy μοντέλο θα χρησιμοποιηθεί για τμηματοποίηση προτάσεων.
+   - `--inference`: επιλέγει τρόπο συμπερασμού κατά την επικύρωση SHACL (`none`, `rdfs`, `owlrl`).
+
+   Παράδειγμα με προσαρμοσμένες επιλογές:
+   ```bash
+   python3 scripts/main.py --inputs demo.txt --shapes shapes.ttl --spacy-model en --inference none
+   ```
+
    Η προαιρετική σημαία `--reason` τρέχει τον ενσωματωμένο reasoner της OWLready2 πριν τον έλεγχο SHACL.
    Για να λειτουργήσει, απαιτείται εγκατεστημένο Java (π.χ. OpenJDK).
 

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,27 @@
+import pathlib
+
+from scripts.main import run_pipeline
+from ontology_guided.llm_interface import LLMInterface
+
+
+def test_run_pipeline_custom_settings(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.chdir(tmp_path)
+
+    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+        return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
+
+    monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    inputs = [str(root / "demo.txt")]
+    shapes = str(root / "shapes.ttl")
+
+    result = run_pipeline(
+        inputs,
+        shapes,
+        "http://example.com/atm#",
+        spacy_model="en",
+        inference="none",
+    )
+    assert result["shacl_conforms"] is True


### PR DESCRIPTION
## Summary
- Add `--spacy-model` and `--inference` flags to CLI and pipeline, forwarding them to `DataLoader` and `SHACLValidator`.
- Document new flags with usage examples in the README.
- Test `run_pipeline` with non-default `spacy_model` and `inference` values.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894731028ec83309106dc3bb70bb447