### PR TITLE
Add caching layer to LLMInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ results/
 venv
 uploads/
 .pytest_cache/
+cache/

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -2,7 +2,7 @@ import openai
 from ontology_guided.llm_interface import LLMInterface
 import time
 
-def test_generate_owl_with_mock(monkeypatch):
+def test_generate_owl_with_mock(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     # Fake response structure mimicking openai return
     class FakeMessage:
@@ -26,12 +26,12 @@ ex:A ex:B ex:C .
     # Patch the OpenAI API call
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
 
-    llm = LLMInterface(api_key="dummy", model="gpt-4")
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
     result = llm.generate_owl(["irrelevant"], "{sentence}")
     assert result == ["@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."]
 
 
-def test_generate_owl_exit_on_error(monkeypatch):
+def test_generate_owl_exit_on_error(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     def fake_create(*args, **kwargs):
         raise openai.OpenAIError("boom")
@@ -39,12 +39,12 @@ def test_generate_owl_exit_on_error(monkeypatch):
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
     monkeypatch.setattr(time, "sleep", lambda *args, **kwargs: None)
 
-    llm = LLMInterface(api_key="dummy", model="gpt-4")
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
     result = llm.generate_owl(["irrelevant"], "{sentence}", max_retries=1, retry_delay=0)
     assert result == []
 
 
-def test_generate_owl_retry_then_success(monkeypatch):
+def test_generate_owl_retry_then_success(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     class FakeMessage:
         def __init__(self, content):
@@ -72,12 +72,12 @@ ex:A ex:B ex:C .
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
     monkeypatch.setattr(time, "sleep", lambda *args, **kwargs: None)
 
-    llm = LLMInterface(api_key="dummy", model="gpt-4")
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
     result = llm.generate_owl(["irrelevant"], "{sentence}", max_retries=2, retry_delay=0)
     assert result == ["@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."]
 
 
-def test_generate_owl_with_terms(monkeypatch):
+def test_generate_owl_with_terms(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
     class FakeMessage:
@@ -100,7 +100,37 @@ def test_generate_owl_with_terms(monkeypatch):
 
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
 
-    llm = LLMInterface(api_key="dummy", model="gpt-4")
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
     llm.generate_owl(["irrelevant"], "{sentence}", available_terms=(['ex:Class'], ['ex:prop']))
     assert 'ex:Class' in captured['prompt']
     assert 'ex:prop' in captured['prompt']
+
+
+def test_generate_owl_uses_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    class FakeMessage:
+        def __init__(self, content):
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, content):
+            self.message = FakeMessage(content)
+
+    class FakeResponse:
+        def __init__(self, content):
+            self.choices = [FakeChoice(content)]
+
+    calls = {"count": 0}
+
+    def fake_create(*args, **kwargs):
+        calls["count"] += 1
+        return FakeResponse("ex:A ex:B ex:C .")
+
+    monkeypatch.setattr(openai.chat.completions, "create", fake_create)
+
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
+    result1 = llm.generate_owl(["same"], "{sentence}")
+    result2 = llm.generate_owl(["same"], "{sentence}")
+    assert result1 == result2 == ["ex:A ex:B ex:C ."]
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- cache LLM responses on disk via hash of sentence and terms
- check cache before API call and save responses afterward
- add tests for caching and ignore cache dir

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689475c177288330bc0c9d6175247712