### PR TITLE
Add repair and reason options to web interface

### DIFF
--- a/scripts/web_app.py
+++ b/scripts/web_app.py
@@ -32,6 +32,8 @@ FORM_HTML = """<!doctype html>
     <textarea name="text" rows="6"></textarea><br><br>
     <label>File:</label> <input type="file" name="file"><br><br>
     <label>Ontologies:</label> <input type="file" name="ontologies" multiple><br><br>
+    <label>Repair:</label> <input type="checkbox" name="repair">
+    <label>Reason:</label> <input type="checkbox" name="reason"><br><br>
     <input type="submit" value="Run Pipeline">
   </form>
 
@@ -98,13 +100,15 @@ def index():
                 ontology_files.append(o_path)
         if not inputs:
             return "No input provided", 400
+        repair_flag = bool(request.form.get("repair"))
+        reason_flag = bool(request.form.get("reason"))
         result = run_pipeline(
             inputs,
             "shapes.ttl",
             "http://example.com/atm#",
             ontologies=ontology_files,
-            repair=True,
-            reason=True,
+            repair=repair_flag,
+            reason=reason_flag,
         )
         ontology_path = result.get("repaired_ttl", result.get("combined_ttl"))
         with open(ontology_path, "r", encoding="utf-8") as f:

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,52 @@
+from scripts import web_app
+
+
+def _fake_result(path):
+    return {
+        "combined_ttl": str(path),
+        "sentences": [],
+        "owl_snippets": [],
+        "reasoner": "",
+        "shacl_conforms": True,
+        "shacl_report": "",
+    }
+
+
+def test_web_app_flags(monkeypatch, tmp_path):
+    dummy = tmp_path / "out.ttl"
+    dummy.write_text("")
+    called = {}
+
+    def fake_run_pipeline(inputs, shapes, base_ns, ontologies=None, repair=False, reason=False):
+        called["repair"] = repair
+        called["reason"] = reason
+        return _fake_result(dummy)
+
+    monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
+    monkeypatch.chdir(tmp_path)
+    client = web_app.app.test_client()
+    data = {"text": "hi", "repair": "on", "reason": "on"}
+    resp = client.post("/", data=data)
+    assert resp.status_code == 200
+    assert called["repair"] is True
+    assert called["reason"] is True
+
+
+def test_web_app_flags_default(monkeypatch, tmp_path):
+    dummy = tmp_path / "out.ttl"
+    dummy.write_text("")
+    called = {}
+
+    def fake_run_pipeline(inputs, shapes, base_ns, ontologies=None, repair=False, reason=False):
+        called["repair"] = repair
+        called["reason"] = reason
+        return _fake_result(dummy)
+
+    monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
+    monkeypatch.chdir(tmp_path)
+    client = web_app.app.test_client()
+    data = {"text": "hi"}
+    resp = client.post("/", data=data)
+    assert resp.status_code == 200
+    assert called["repair"] is False
+    assert called["reason"] is False


### PR DESCRIPTION
## Summary
- Add **Repair** and **Reason** checkboxes to web_app form and forward their values to the pipeline
- Cover new form options with Flask test client tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894787f7c448330af4f6b387eb6e4bc