### PR TITLE
Use logging instead of prints

### DIFF
--- a/ontology_guided/llm_interface.py
+++ b/ontology_guided/llm_interface.py
@@ -6,6 +6,7 @@ import time
 import hashlib
 import json
 from pathlib import Path
+import logging
 
 class LLMInterface:
     def __init__(self, api_key: str, model: str = "gpt-4", cache_dir: Optional[str] = None):
@@ -13,6 +14,7 @@ class LLMInterface:
         self.model = model
         self.cache_dir = Path(cache_dir or Path(__file__).resolve().parent.parent / "cache")
         self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.logger = logging.getLogger(__name__)
 
     def _cache_file(self, sentence: str, available_terms: Optional[Tuple[List[str], List[str]]]):
         classes, properties = available_terms or ([], [])
@@ -79,9 +81,9 @@ class LLMInterface:
                     break
                 except (openai.OpenAIError, httpx.HTTPError) as e:
                     attempts += 1
-                    print(f"LLM call failed: {e}")
+                    self.logger.warning("LLM call failed: %s", e)
                     if attempts > max_retries:
-                        print("Exiting gracefully.")
+                        self.logger.error("Exiting gracefully.")
                         return results
                     time.sleep(retry_delay)
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -70,27 +70,27 @@ def run_pipeline(
     builder.save("results/combined.owl", fmt="xml")
     pipeline["combined_ttl"] = "results/combined.ttl"
     pipeline["combined_owl"] = "results/combined.owl"
-    print("Saved results/combined.ttl and results/combined.owl")
+    logger.info("Saved results/combined.ttl and results/combined.owl")
 
     if reason:
         from ontology_guided.reasoner import run_reasoner, ReasonerError
-        print("Running OWL reasoner...")
+        logger.info("Running OWL reasoner...")
         try:
             run_reasoner(pipeline["combined_owl"])
             pipeline["reasoner"] = "OWL reasoning completed successfully."
         except ReasonerError as exc:
-            print(exc)
+            logger.error(exc)
             pipeline["reasoner"] = f"Reasoner error: {exc}"
 
     validator = SHACLValidator(pipeline["combined_ttl"], shapes, inference=inference)
     conforms, report_text, _ = validator.run_validation()
-    print("Conforms:", conforms)
-    print(report_text)
+    logger.info("Conforms: %s", conforms)
+    logger.info(report_text)
     pipeline["shacl_conforms"] = conforms
     pipeline["shacl_report"] = report_text
 
     if not conforms and repair:
-        print("Running repair loop...")
+        logger.info("Running repair loop...")
         repairer = RepairLoop(pipeline["combined_ttl"], shapes, api_key)
         repairer.run()
         pipeline["repaired_ttl"] = "results/repaired.ttl"


### PR DESCRIPTION
## Summary
- replace print statements with logging in pipeline, LLM interface, and repair loop for structured log output
- capture LLMInterface error logs in tests using `caplog`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68947f1547088330b67f2bc849caa81c