### PR TITLE
Revalidate ontology after repair and add regression test

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -44,6 +44,14 @@ class RepairLoop:
         self.builder.save("results/repaired.owl", fmt="xml")
         logger.info("Repaired ontology saved to results/repaired.ttl and results/repaired.owl")
 
+        repaired_validator = SHACLValidator("results/repaired.ttl", self.shapes_path)
+        repaired_conforms, repaired_report, _ = repaired_validator.run_validation()
+        if not repaired_conforms:
+            logger.error("Remaining SHACL violations:\n%s", repaired_report)
+            raise RuntimeError(
+                "Repaired ontology still violates SHACL constraints."
+            )
+
 
 def main():
     load_dotenv()

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -1,0 +1,41 @@
+import ontology_guided.repair_loop as repair_loop
+from ontology_guided.repair_loop import RepairLoop
+from ontology_guided.llm_interface import LLMInterface
+
+
+def test_repair_loop_validates_twice(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.chdir(tmp_path)
+
+    data_path = tmp_path / "combined.ttl"
+    data_path.write_text("""@prefix atm: <http://example.com/atm#> .\natm:alice a atm:User .""", encoding="utf-8")
+    shapes_path = tmp_path / "shapes.ttl"
+    shapes_path.write_text("", encoding="utf-8")
+
+    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+        return ["atm:bob a atm:User ."]
+
+    monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
+
+    class FakeValidator:
+        instances = []
+        runs = []
+
+        def __init__(self, data_path, shapes_path):
+            self.data_path = data_path
+            self.shapes_path = shapes_path
+            FakeValidator.instances.append(self)
+
+        def run_validation(self):
+            FakeValidator.runs.append(self.data_path)
+            if len(FakeValidator.runs) == 1:
+                return False, "error", None
+            return True, "", None
+
+    monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
+
+    repairer = RepairLoop(str(data_path), str(shapes_path), api_key="dummy")
+    repairer.run()
+
+    assert len(FakeValidator.runs) == 2
+    assert FakeValidator.runs[1].endswith("results/repaired.ttl")


### PR DESCRIPTION
## Summary
- Re-run SHACL validation on the repaired ontology and stop when violations persist
- Add a unit test that mocks the validator and LLM to ensure the second validation is executed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689481cd7e4c8330830427d2fac2af28