### PR TITLE
Handle missing and unsupported requirement files

### DIFF
--- a/ontology_guided/data_loader.py
+++ b/ontology_guided/data_loader.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from typing import List
 import spacy
 from docx import Document  # pip install python-docx
@@ -33,12 +34,15 @@ class DataLoader:
         texts = []
         for path in input_paths:
             if not os.path.exists(path):
+                logging.warning("File %s does not exist and will be skipped", path)
                 continue
             ext = os.path.splitext(path)[1].lower()
             if ext == ".txt":
                 texts.append(self.load_text_file(path))
             elif ext == ".docx":
                 texts.append(self.load_docx_file(path))
+            else:
+                raise ValueError(f"Unsupported file extension: {ext}")
         return texts
 
     def preprocess_text(self, text: str) -> List[str]:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,6 @@
+import logging
+import pytest
+
 from ontology_guided.data_loader import DataLoader
 
 
@@ -9,6 +12,21 @@ def test_demo_txt_loading_and_preprocessing():
     for t in texts:
         sentences.extend(loader.preprocess_text(t))
     assert sentences == [
-        "The ATM must log all user transactions after card insertion."
+        "The ATM must log all user transactions after card insertion.",
     ]
+
+
+def test_load_requirements_warns_and_raises(tmp_path, caplog):
+    loader = DataLoader()
+
+    missing_file = tmp_path / "missing.txt"
+    with caplog.at_level(logging.WARNING):
+        texts = loader.load_requirements([str(missing_file)])
+    assert "does not exist" in caplog.text
+    assert texts == []
+
+    bad_file = tmp_path / "bad.pdf"
+    bad_file.write_text("dummy")
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        loader.load_requirements([str(bad_file)])
 


### PR DESCRIPTION
## Summary
- warn when requirement files are missing
- validate requirement file extensions and raise ValueError on unsupported types
- test loader warning and error behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894835bcc748330b8e4ec00c375609a