### PR TITLE
feat: allow custom SHACL and base IRI in web app

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,4 +1,5 @@
 from scripts import web_app
+from io import BytesIO
 
 
 def _fake_result(path):
@@ -50,3 +51,23 @@ def test_web_app_flags_default(monkeypatch, tmp_path):
     assert resp.status_code == 200
     assert called["repair"] is False
     assert called["reason"] is False
+
+
+def test_web_app_custom_shacl_and_base(monkeypatch, tmp_path):
+    dummy = tmp_path / "out.ttl"
+    dummy.write_text("")
+    called = {}
+
+    def fake_run_pipeline(inputs, shapes, base_ns, ontologies=None, repair=False, reason=False):
+        called["shapes"] = shapes
+        called["base_ns"] = base_ns
+        return _fake_result(dummy)
+
+    monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
+    monkeypatch.chdir(tmp_path)
+    client = web_app.app.test_client()
+    data = {"text": "hi", "base_iri": "http://example.com/custom#", "shacl": (BytesIO(b"data"), "custom.ttl")}
+    resp = client.post("/", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert called["base_ns"] == "http://example.com/custom#"
+    assert called["shapes"].endswith("custom.ttl")

--- a/tests/test_web_cleanup.py
+++ b/tests/test_web_cleanup.py
@@ -1,4 +1,5 @@
 from scripts import web_app
+from io import BytesIO
 
 
 def _fake_result(path):
@@ -22,8 +23,10 @@ def test_temporary_files_removed(monkeypatch, tmp_path):
     monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
     monkeypatch.chdir(tmp_path)
     client = web_app.app.test_client()
-    resp = client.post("/", data={"text": "hi"})
+    data = {"text": "hi", "shacl": (BytesIO(b"data"), "shape.ttl")}
+    resp = client.post("/", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
     assert not dummy.exists()
     assert not (tmp_path / "uploads" / "input.txt").exists()
+    assert not (tmp_path / "uploads" / "shape.ttl").exists()
 


### PR DESCRIPTION
## Summary
- add base IRI and SHACL file inputs to web form
- forward uploaded SHACL and base IRI to pipeline and remove temp files
- test new web options and cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894884ece308330b0d258f451ca315e