### PR TITLE
Add optional RBO and lexical ontologies

### DIFF
--- a/ontologies/lexical.ttl
+++ b/ontologies/lexical.ttl
@@ -1,0 +1,1 @@
+@prefix ex: <http://example.com/lexical#> .

--- a/ontologies/rbo.ttl
+++ b/ontologies/rbo.ttl
@@ -1,0 +1,1 @@
+@prefix ex: <http://example.com/rbo#> .


### PR DESCRIPTION
## Summary
- allow pipeline to include RBO and lexical ontologies via new flags
- define default locations for bundled ontologies and load them when flags are set
- add placeholder TTL files for RBO and lexical ontologies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68948d519de883308d67432ef342a998