### PR TITLE
Add ATM log shape and update validation tests

### DIFF
--- a/shapes.ttl
+++ b/shapes.ttl
@@ -76,4 +76,21 @@ atm:ATMShape
         sh:minCount 1 ;
         sh:datatype xsd:string ;
     ] .
+
+# Τα ATM πρέπει να καταγράφουν συναλλαγές με χρήστη actor
+atm:ATMLogShape
+    a sh:NodeShape ;
+    sh:targetClass atm:ATM ;
+    sh:property [
+        sh:path atm:logs ;
+        sh:minCount 1 ;
+        sh:class atm:Transaction ;
+        sh:node [
+            sh:property [
+                sh:path atm:actor ;
+                sh:minCount 1 ;
+                sh:class atm:User ;
+            ] ;
+        ] ;
+    ] .
     

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -17,7 +17,8 @@ atm:alice a atm:User ;
 atm:acc123 a atm:Account ;
     atm:balance "100.0"^^xsd:decimal .
 atm:atm1 a atm:ATM ;
-    atm:location "Center"^^xsd:string .
+    atm:location "Center"^^xsd:string ;
+    atm:logs atm:tx1 .
 atm:tx1 a atm:Transaction ;
     atm:actor atm:alice ;
     atm:target atm:acc123 ;
@@ -46,11 +47,13 @@ atm:alice a atm:User ;
     atm:owns atm:acc123 .
 atm:acc123 a atm:Account ;
     atm:balance "100.0"^^xsd:decimal .
-atm:atm1 a atm:ATM ;
-    atm:location "Center"^^xsd:string .
-atm:tx2 a atm:Transaction ;
+atm:cash a atm:Item .
+atm:act1 a atm:Action ;
     atm:actor atm:alice ;
-    atm:target atm:acc123 .
+    atm:object atm:cash .
+atm:atm1 a atm:ATM ;
+    atm:location "Center"^^xsd:string ;
+    atm:logs atm:act1 .
 """
     data_path = _write_temp(tmp_path, "invalid.ttl", data)
     shapes_path = Path(__file__).resolve().parent.parent / "shapes.ttl"


### PR DESCRIPTION
## Summary
- add SHACL shape ensuring ATMs log user transactions
- test valid ATM log data and improper logs

## Testing
- `pytest tests/test_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_68948e8f1e3c8330bdd1533ac0175c71