### PR TITLE
feat: allow dynamic ontology prefix

### DIFF
--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -7,12 +7,13 @@ from rdflib.namespace import RDF, RDFS, OWL, XSD
 class OntologyBuilder:
     """Μετατρέπει τμήματα Turtle σε ενιαία οντολογία."""
 
-    def __init__(self, base_iri: str, ontology_files=None):
+    def __init__(self, base_iri: str, prefix: str | None = None, ontology_files=None):
         if not base_iri.endswith("#"):
             base_iri += "#"
         self.base_iri = base_iri
+        self.prefix = prefix or base_iri.rstrip("#").split("/")[-1]
         self.graph = Graph()
-        self.graph.bind("atm", self.base_iri)
+        self.graph.bind(self.prefix, self.base_iri)
         if ontology_files:
             for path in ontology_files:
                 self.graph.parse(path)
@@ -21,7 +22,7 @@ class OntologyBuilder:
 
     def _build_header(self):
         prefixes = {
-            "atm": self.base_iri,
+            self.prefix: self.base_iri,
             "rdf": str(RDF),
             "rdfs": str(RDFS),
             "owl": str(OWL),

--- a/tests/test_ontology_builder.py
+++ b/tests/test_ontology_builder.py
@@ -20,7 +20,7 @@ ex:ClassA a owl:Class .
 """,
         encoding="utf-8",
     )
-    ob = OntologyBuilder('http://example.com/atm#', [str(ext)])
+    ob = OntologyBuilder('http://example.com/atm#', ontology_files=[str(ext)])
     classes, _ = ob.get_available_terms()
     assert "ex:ClassA" in classes
     assert "@prefix ex:" in ob.header


### PR DESCRIPTION
## Summary
- allow `OntologyBuilder` to accept optional prefix and derive it from the base IRI
- bind rdflib graph using the dynamic prefix and update header generation
- adjust tests to use the new signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894906b2dfc8330a2c274a406af3397