### PR TITLE
feat: allow custom shapes and base iri

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,3 +1,5 @@
+import io
+import os
 from scripts import web_app
 
 
@@ -40,6 +42,8 @@ def test_web_app_flags_default(monkeypatch, tmp_path):
     def fake_run_pipeline(inputs, shapes, base_ns, ontologies=None, repair=False, reason=False):
         called["repair"] = repair
         called["reason"] = reason
+        called["shapes"] = shapes
+        called["base_ns"] = base_ns
         return _fake_result(dummy)
 
     monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
@@ -50,3 +54,31 @@ def test_web_app_flags_default(monkeypatch, tmp_path):
     assert resp.status_code == 200
     assert called["repair"] is False
     assert called["reason"] is False
+    assert called["shapes"] == "shapes.ttl"
+    assert called["base_ns"] == "http://example.com/atm#"
+
+
+def test_web_app_custom_shapes_and_base(monkeypatch, tmp_path):
+    dummy = tmp_path / "out.ttl"
+    dummy.write_text("")
+    called = {}
+
+    def fake_run_pipeline(inputs, shapes, base_ns, ontologies=None, repair=False, reason=False):
+        called["shapes"] = shapes
+        called["base_ns"] = base_ns
+        called["exists"] = os.path.exists(shapes)
+        return _fake_result(dummy)
+
+    monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
+    monkeypatch.chdir(tmp_path)
+    client = web_app.app.test_client()
+    data = {
+        "text": "hi",
+        "base_iri": "http://test.com/base#",
+        "shapes": (io.BytesIO(b"shape"), "shape.ttl"),
+    }
+    resp = client.post("/", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert called["base_ns"] == "http://test.com/base#"
+    assert called["shapes"] == os.path.join("uploads", "shape.ttl")
+    assert called["exists"] is True

--- a/tests/test_web_cleanup.py
+++ b/tests/test_web_cleanup.py
@@ -1,3 +1,4 @@
+import io
 from scripts import web_app
 
 
@@ -22,8 +23,10 @@ def test_temporary_files_removed(monkeypatch, tmp_path):
     monkeypatch.setattr(web_app, "run_pipeline", fake_run_pipeline)
     monkeypatch.chdir(tmp_path)
     client = web_app.app.test_client()
-    resp = client.post("/", data={"text": "hi"})
+    data = {"text": "hi", "shapes": (io.BytesIO(b"s"), "s.ttl")}
+    resp = client.post("/", data=data, content_type="multipart/form-data")
     assert resp.status_code == 200
     assert not dummy.exists()
     assert not (tmp_path / "uploads" / "input.txt").exists()
+    assert not (tmp_path / "uploads" / "s.ttl").exists()
 


### PR DESCRIPTION
## Summary
- accept custom SHACL shapes file and base IRI in web form
- handle shapes upload and base IRI in web handler and clean up
- test base IRI and shapes handling including defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894947e438c8330a0db3862f339de8c