### PR TITLE
Stream requirement loading with generators

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -56,10 +56,11 @@ def run_pipeline(
     pipeline = {}
 
     loader = DataLoader(spacy_model=spacy_model)
-    texts = loader.load_requirements(inputs)
-    pipeline["texts"] = texts
+    texts_iter = loader.load_requirements(inputs)
+    pipeline["texts"] = []
     sentences = []
-    for text in texts:
+    for text in texts_iter:
+        pipeline["texts"].append(text)
         sentences.extend(loader.preprocess_text(text))
     if not sentences:
         raise RuntimeError("No requirements found in inputs")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -6,7 +6,7 @@ from ontology_guided.data_loader import DataLoader
 
 def test_demo_txt_loading_and_preprocessing():
     loader = DataLoader()
-    texts = loader.load_requirements(["demo.txt"])
+    texts = list(loader.load_requirements(["demo.txt"]))
     assert len(texts) == 1
     sentences = []
     for t in texts:
@@ -21,12 +21,12 @@ def test_load_requirements_warns_and_raises(tmp_path, caplog):
 
     missing_file = tmp_path / "missing.txt"
     with caplog.at_level(logging.WARNING):
-        texts = loader.load_requirements([str(missing_file)])
+        texts = list(loader.load_requirements([str(missing_file)]))
     assert "does not exist" in caplog.text
     assert texts == []
 
     bad_file = tmp_path / "bad.pdf"
     bad_file.write_text("dummy")
     with pytest.raises(ValueError, match="Unsupported file extension"):
-        loader.load_requirements([str(bad_file)])
+        list(loader.load_requirements([str(bad_file)]))
 


### PR DESCRIPTION
## Summary
- Stream text file reading line-by-line with generators
- Expose requirement loading as iterator and consume lazily in pipeline
- Adjust tests for generator-based interfaces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a1d0869083308486e04e04483920