### PR TITLE
Process text in chunks with spaCy

### DIFF
--- a/ontology_guided/data_loader.py
+++ b/ontology_guided/data_loader.py
@@ -14,13 +14,15 @@ def clean_text(text: str) -> str:
 class DataLoader:
     """Κλάση για φόρτωση και προεπεξεργασία φυσικών γλώσσών απαιτήσεων."""
 
-    def __init__(self, spacy_model: str = "en_core_web_sm"):
+    def __init__(self, spacy_model: str = "en_core_web_sm", max_length: int = 2_000_000):
         try:
             self.nlp = spacy.load(spacy_model)
         except OSError:
             # Fallback to blank English model if not installed
             self.nlp = spacy.blank("en")
             self.nlp.add_pipe("sentencizer")
+        # Increase the maximum allowed document length to handle large files
+        self.nlp.max_length = max_length
 
     def load_text_file(self, file_path: str) -> Iterator[str]:
         with open(file_path, "r", encoding="utf-8") as f:
@@ -44,7 +46,19 @@ class DataLoader:
             else:
                 raise ValueError(f"Unsupported file extension: {ext}")
 
-    def preprocess_text(self, text: str) -> List[str]:
-        cleaned = clean_text(text)
-        doc = self.nlp(cleaned)
-        return [sent.text.strip() for sent in doc.sents]
+    def preprocess_text(
+        self, text: str, batch_size: int = 100, n_process: int = 1
+    ) -> List[str]:
+        """Καθαρίζει το κείμενο και το επεξεργάζεται τμηματικά με το spaCy.
+
+        Το κείμενο χωρίζεται σε γραμμές, καθαρίζεται και στη συνέχεια
+        επεξεργάζεται με την ``nlp.pipe`` ώστε να αποφεύγεται η φόρτωση
+        ολόκληρου του κειμένου στη μνήμη.
+        """
+
+        lines = (line for line in text.splitlines() if line.strip())
+        cleaned_iter = (clean_text(line) for line in lines)
+        sentences: List[str] = []
+        for doc in self.nlp.pipe(cleaned_iter, batch_size=batch_size, n_process=n_process):
+            sentences.extend(sent.text.strip() for sent in doc.sents)
+        return sentences


### PR DESCRIPTION
## Summary
- Handle large files by setting a higher `nlp.max_length`.
- Stream text preprocessing with `nlp.pipe` to avoid loading entire documents.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894a38839608330909ad86c24706c2c