### PR TITLE
Handle invalid turtle snippets

### DIFF
--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -25,3 +25,33 @@ def test_run_pipeline_custom_settings(monkeypatch, tmp_path):
         inference="none",
     )
     assert result["shacl_conforms"] is True
+    assert result["failed_snippets"] == []
+
+
+def test_run_pipeline_collects_failed_snippets(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.chdir(tmp_path)
+
+    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+        return ["invalid turtle"]
+
+    monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    inputs = [str(root / "demo.txt")]
+    shapes = str(root / "shapes.ttl")
+
+    result = run_pipeline(
+        inputs,
+        shapes,
+        "http://example.com/atm#",
+        spacy_model="en",
+        inference="none",
+    )
+
+    assert result["failed_snippets"] == [
+        {
+            "sentence": "The ATM must log all user transactions after card insertion.",
+            "snippet": "invalid turtle",
+        }
+    ]


### PR DESCRIPTION
## Summary
- skip invalid OWL snippets instead of crashing the pipeline
- track skipped snippets and their source sentences via `failed_snippets`
- test failure collection in `run_pipeline`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ac2921c08330a99cba69968ba092