### PR TITLE
Validate Turtle snippets and retry on invalid output

### DIFF
--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -2,6 +2,7 @@ import openai
 from ontology_guided.llm_interface import LLMInterface
 import time
 import logging
+import pytest
 
 def test_generate_owl_with_mock(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
@@ -102,7 +103,7 @@ def test_generate_owl_with_terms(monkeypatch, tmp_path):
 
     def fake_create(*args, **kwargs):
         captured["prompt"] = kwargs["messages"][1]["content"]
-        return FakeResponse("ex:A ex:B ex:C .")
+        return FakeResponse("""@prefix ex: <http://example.com/> .\nex:A ex:prop ex:B .""")
 
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
 
@@ -131,12 +132,73 @@ def test_generate_owl_uses_cache(monkeypatch, tmp_path):
 
     def fake_create(*args, **kwargs):
         calls["count"] += 1
-        return FakeResponse("ex:A ex:B ex:C .")
+        return FakeResponse("""@prefix ex: <http://example.com/> .\nex:A ex:B ex:C .""")
 
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
 
     llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
     result1 = llm.generate_owl(["same"], "{sentence}")
     result2 = llm.generate_owl(["same"], "{sentence}")
-    assert result1 == result2 == ["ex:A ex:B ex:C ."]
+    assert result1 == result2 == ["@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."]
     assert calls["count"] == 1
+
+
+def test_generate_owl_retry_on_invalid_turtle(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    class FakeMessage:
+        def __init__(self, content):
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, content):
+            self.message = FakeMessage(content)
+
+    class FakeResponse:
+        def __init__(self, content):
+            self.choices = [FakeChoice(content)]
+
+    calls = {"count": 0}
+    prompts = []
+
+    def fake_create(*args, **kwargs):
+        prompts.append(kwargs["messages"][1]["content"])
+        if calls["count"] == 0:
+            calls["count"] += 1
+            return FakeResponse("ex:A ex:B ex:C .")
+        return FakeResponse("""@prefix ex: <http://example.com/> .\nex:A ex:B ex:C .""")
+
+    monkeypatch.setattr(openai.chat.completions, "create", fake_create)
+    monkeypatch.setattr(time, "sleep", lambda *args, **kwargs: None)
+
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
+    result = llm.generate_owl(["irrelevant"], "{sentence}", max_retries=2, retry_delay=0)
+    assert result == ["@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."]
+    assert len(prompts) == 2
+    assert "Previous output was invalid Turtle" in prompts[1]
+
+
+def test_generate_owl_raises_after_invalid_turtle(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    class FakeMessage:
+        def __init__(self, content):
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, content):
+            self.message = FakeMessage(content)
+
+    class FakeResponse:
+        def __init__(self, content):
+            self.choices = [FakeChoice(content)]
+
+    def fake_create(*args, **kwargs):
+        return FakeResponse("ex:A ex:B ex:C .")
+
+    monkeypatch.setattr(openai.chat.completions, "create", fake_create)
+    monkeypatch.setattr(time, "sleep", lambda *args, **kwargs: None)
+
+    llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
+    with pytest.raises(ValueError):
+        llm.generate_owl(["irrelevant"], "{sentence}", max_retries=1, retry_delay=0)


### PR DESCRIPTION
## Summary
- parse and validate Turtle snippets returned by LLM in `generate_owl`
- retry with clarification if invalid Turtle encountered and stop after retries exhausted
- test coverage for retry/raise logic and caching with valid Turtle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894adafb1fc83308627977e29df0e8e