### PR TITLE
Expand RBO and lexical ontologies with core classes

### DIFF
--- a/ontologies/lexical.ttl
+++ b/ontologies/lexical.ttl
@@ -1,1 +1,25 @@
-@prefix ex: <http://example.com/lexical#> .
+@prefix lex: <http://example.com/lexical#> .
+@prefix ex: <http://example.com/lexical/example#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+lex:Word a rdfs:Class .
+
+lex:Noun a rdfs:Class ;
+    rdfs:subClassOf lex:Word .
+
+lex:synonym a rdf:Property ;
+    rdfs:domain lex:Word ;
+    rdfs:range lex:Word .
+
+lex:antonym a rdf:Property ;
+    rdfs:domain lex:Word ;
+    rdfs:range lex:Word .
+
+ex:fast a lex:Word .
+
+ex:quick a lex:Word ;
+    lex:synonym ex:fast .
+
+ex:slow a lex:Word ;
+    lex:antonym ex:fast .

--- a/ontologies/rbo.ttl
+++ b/ontologies/rbo.ttl
@@ -1,1 +1,29 @@
-@prefix ex: <http://example.com/rbo#> .
+@prefix rbo: <http://example.com/rbo#> .
+@prefix ex: <http://example.com/rbo/example#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+rbo:Requirement a rdfs:Class .
+
+rbo:Action a rdfs:Class .
+
+rbo:Actor a rdfs:Class .
+
+rbo:FunctionalRequirement a rdfs:Class ;
+    rdfs:subClassOf rbo:Requirement .
+
+rbo:requiresAction a rdf:Property ;
+    rdfs:domain rbo:Requirement ;
+    rdfs:range rbo:Action .
+
+rbo:performedBy a rdf:Property ;
+    rdfs:domain rbo:Action ;
+    rdfs:range rbo:Actor .
+
+ex:REQ1 a rbo:FunctionalRequirement ;
+    rbo:requiresAction ex:LoginAction .
+
+ex:LoginAction a rbo:Action ;
+    rbo:performedBy ex:User .
+
+ex:User a rbo:Actor .


### PR DESCRIPTION
## Summary
- extend rbo.ttl with Requirement, Action, Actor classes and sample relations
- expand lexical.ttl with Word class hierarchy and synonym/antonym links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b35e7aec83309b4f863bf467833f