### PR TITLE
feat: allow loading ontology directory

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -31,6 +31,7 @@ def run_pipeline(
     shapes,
     base_iri,
     ontologies=None,
+    ontology_dir=None,
     model="gpt-4",
     repair=False,
     reason=False,
@@ -46,7 +47,8 @@ def run_pipeline(
     as the web interface can display each stage to the user. When ``load_rbo``
     or ``load_lexical`` are ``True``, the predefined ontology files at
     ``RBO_ONTOLOGY_PATH`` and ``LEXICAL_ONTOLOGY_PATH`` are included
-    automatically.
+    automatically.  ``ontology_dir`` allows specifying a directory from which
+    all ``.ttl`` files will be loaded as additional ontologies.
     """
     load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
@@ -78,6 +80,10 @@ def run_pipeline(
     sentences_iter = sentence_iterator()
 
     ontology_files = list(ontologies or [])
+    if ontology_dir:
+        for name in os.listdir(ontology_dir):
+            if name.endswith(".ttl"):
+                ontology_files.append(os.path.join(ontology_dir, name))
     if load_rbo:
         ontology_files.append(RBO_ONTOLOGY_PATH)
     if load_lexical:
@@ -179,6 +185,11 @@ def main():
     parser.add_argument("--shapes", default="shapes.ttl", help="SHACL shapes file")
     parser.add_argument("--base-iri", default="http://example.com/atm#", help="Base IRI for ontology")
     parser.add_argument("--ontologies", nargs="*", default=[], help="Additional ontology files to load")
+    parser.add_argument(
+        "--ontology-dir",
+        default=None,
+        help="Directory from which to load all .ttl ontology files",
+    )
     parser.add_argument("--rbo", action="store_true", help="Include the RBO ontology")
     parser.add_argument("--lexical", action="store_true", help="Include the lexical ontology")
     parser.add_argument("--model", default="gpt-4", help="OpenAI model")
@@ -202,6 +213,7 @@ def main():
         args.shapes,
         args.base_iri,
         ontologies=args.ontologies,
+        ontology_dir=args.ontology_dir,
         model=args.model,
         repair=args.repair,
         reason=args.reason,

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import scripts.main as main
 from scripts.main import run_pipeline
 from ontology_guided.llm_interface import LLMInterface
 
@@ -55,3 +56,50 @@ def test_run_pipeline_collects_failed_snippets(monkeypatch, tmp_path):
             "snippet": "invalid turtle",
         }
     ]
+
+
+def test_run_pipeline_ontology_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.chdir(tmp_path)
+
+    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+        return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
+
+    monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
+
+    onto_dir = tmp_path / "ontos"
+    onto_dir.mkdir()
+    ttl_file = onto_dir / "extra.ttl"
+    ttl_file.write_text("@prefix : <http://example.com/> .")
+
+    captured = {}
+
+    class FakeBuilder:
+        def __init__(self, base_iri, ontology_files=None):
+            captured["files"] = list(ontology_files or [])
+
+        def get_available_terms(self):
+            return []
+
+        def parse_turtle(self, *args, **kwargs):
+            pass
+
+        def save(self, path, fmt):
+            pathlib.Path(path).write_text("")
+
+    monkeypatch.setattr(main, "OntologyBuilder", FakeBuilder)
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    inputs = [str(root / "demo.txt")]
+    shapes = str(root / "shapes.ttl")
+
+    run_pipeline(
+        inputs,
+        shapes,
+        "http://example.com/atm#",
+        ontology_dir=str(onto_dir),
+        spacy_model="en",
+        inference="none",
+    )
+
+    assert str(ttl_file) in captured["files"]


### PR DESCRIPTION
## Summary
- add `ontology_dir` parameter to pipeline and CLI
- auto-include all `.ttl` files from a specified directory
- document and test ontology directory loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895b4ebbbd48330a4d94b3046f2632e