### PR TITLE
Return structured SHACL violations

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -164,11 +164,11 @@ def run_pipeline(
             pipeline["reasoner"] = f"Reasoner error: {exc}"
 
     validator = SHACLValidator(pipeline["combined_ttl"], shapes, inference=inference)
-    conforms, report_text, _ = validator.run_validation()
+    conforms, report = validator.run_validation()
     logger.info("Conforms: %s", conforms)
-    logger.info(report_text)
+    logger.info("SHACL Report: %s", report)
     pipeline["shacl_conforms"] = conforms
-    pipeline["shacl_report"] = report_text
+    pipeline["shacl_report"] = report
 
     if not conforms and repair:
         logger.info("Running repair loop...")

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -29,8 +29,8 @@ def test_repair_loop_validates_twice(monkeypatch, tmp_path):
         def run_validation(self):
             FakeValidator.runs.append(self.data_path)
             if len(FakeValidator.runs) == 1:
-                return False, "error", None
-            return True, "", None
+                return False, [{"focusNode": "x", "resultPath": "p", "message": "error"}]
+            return True, []
 
     monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -35,8 +35,9 @@ atm:insert1 a atm:CardInsertion ;
     data_path = _write_temp(tmp_path, "valid.ttl", data)
     shapes_path = Path(__file__).resolve().parent.parent / "shapes.ttl"
     validator = SHACLValidator(data_path, str(shapes_path))
-    conforms, _, _ = validator.run_validation()
+    conforms, results = validator.run_validation()
     assert conforms
+    assert results == []
 
 
 def test_validation_non_conforming(tmp_path):
@@ -58,6 +59,8 @@ atm:atm1 a atm:ATM ;
     data_path = _write_temp(tmp_path, "invalid.ttl", data)
     shapes_path = Path(__file__).resolve().parent.parent / "shapes.ttl"
     validator = SHACLValidator(data_path, str(shapes_path))
-    conforms, _, _ = validator.run_validation()
+    conforms, results = validator.run_validation()
     assert not conforms
+    assert isinstance(results, list)
+    assert all({"focusNode", "resultPath", "message"} <= r.keys() for r in results)
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -10,7 +10,7 @@ def _fake_result(path):
         "owl_snippets": [],
         "reasoner": "",
         "shacl_conforms": True,
-        "shacl_report": "",
+        "shacl_report": [],
     }
 
 

--- a/tests/test_web_cleanup.py
+++ b/tests/test_web_cleanup.py
@@ -9,7 +9,7 @@ def _fake_result(path):
         "owl_snippets": [],
         "reasoner": "",
         "shacl_conforms": True,
-        "shacl_report": "",
+        "shacl_report": [],
     }
 
 


### PR DESCRIPTION
## Summary
- Return SHACL validation results as a structured list of violations with focusNode, resultPath, and message.
- Build repair prompts from structured violation data instead of raw text.
- Adjust scripts and tests for the new structured validator output.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b7214dc88330b7b673f746c10c21