### PR TITLE
Add iterative repair loop with reasoning options

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from .validator import SHACLValidator
 from .llm_interface import LLMInterface
 from .ontology_builder import OntologyBuilder
+from .reasoner import run_reasoner, ReasonerError
 
 BASE_IRI = "http://example.com/atm#"
 SHAPES_FILE = "shapes.ttl"
@@ -18,43 +19,72 @@ PROMPT_TEMPLATE = (
 
 
 class RepairLoop:
-    def __init__(self, data_path: str, shapes_path: str, api_key: str):
+    def __init__(
+        self,
+        data_path: str,
+        shapes_path: str,
+        api_key: str,
+        *,
+        kmax: int = 5,
+        reason: bool = False,
+        inference: str = "rdfs",
+    ):
         self.data_path = data_path
         self.shapes_path = shapes_path
+        self.kmax = kmax
+        self.reason = reason
+        self.inference = inference
         self.llm = LLMInterface(api_key=api_key)
         self.builder = OntologyBuilder(BASE_IRI)
 
     def run(self):
         logger = logging.getLogger(__name__)
-        validator = SHACLValidator(self.data_path, self.shapes_path)
-        conforms, violations = validator.run_validation()
-        if conforms:
-            logger.info("No SHACL violations detected. No repair needed.")
-            return
-        logger.info("SHACL Violations: %s", violations)
-        report_text = "\n".join(
-            f"focusNode: {v['focusNode']}, resultPath: {v['resultPath']}, message: {v['message']}"
-            for v in violations
-        )
-        prompt = PROMPT_TEMPLATE.format(violations=report_text)
-        logger.info("Repair prompt:\n%s", prompt)
-        repair_triples = self.llm.generate_owl([prompt], "{sentence}")[0]
-        with open(self.data_path, "r", encoding="utf-8") as f:
-            original = f.read()
-        merged = original + "\n\n" + repair_triples
-        self.builder.parse_turtle(merged, logger=logger)
         os.makedirs("results", exist_ok=True)
-        self.builder.save("results/repaired.ttl", fmt="turtle")
-        self.builder.save("results/repaired.owl", fmt="xml")
-        logger.info("Repaired ontology saved to results/repaired.ttl and results/repaired.owl")
+        current_data = self.data_path
+        k = 0
+        while True:
+            validator = SHACLValidator(current_data, self.shapes_path, inference=self.inference)
+            conforms, violations = validator.run_validation()
+            report_path = os.path.join("results", f"report_{k}.txt")
+            with open(report_path, "w", encoding="utf-8") as f:
+                if conforms:
+                    f.write("Conforms\n")
+                else:
+                    for v in violations:
+                        f.write(
+                            f"focusNode: {v['focusNode']}, resultPath: {v['resultPath']}, message: {v['message']}\n"
+                        )
+            if conforms:
+                logger.info("SHACL validation passed on iteration %d", k)
+                break
+            if k == self.kmax:
+                logger.warning("Reached maximum iterations (%d)", self.kmax)
+                break
 
-        repaired_validator = SHACLValidator("results/repaired.ttl", self.shapes_path)
-        repaired_conforms, repaired_report = repaired_validator.run_validation()
-        if not repaired_conforms:
-            logger.error("Remaining SHACL violations:\n%s", repaired_report)
-            raise RuntimeError(
-                "Repaired ontology still violates SHACL constraints."
-            )
+            logger.info("SHACL Violations: %s", violations)
+            prompts = []
+            for v in violations:
+                report_text = (
+                    f"focusNode: {v['focusNode']}, resultPath: {v['resultPath']}, message: {v['message']}"
+                )
+                prompts.append(PROMPT_TEMPLATE.format(violations=report_text))
+            repair_snippets = self.llm.generate_owl(prompts, "{sentence}")
+            with open(current_data, "r", encoding="utf-8") as f:
+                original = f.read()
+            merged = original + "\n\n" + "\n\n".join(repair_snippets)
+            self.builder = OntologyBuilder(BASE_IRI)
+            self.builder.parse_turtle(merged, logger=logger)
+            ttl_path = os.path.join("results", f"repaired_{k + 1}.ttl")
+            owl_path = os.path.join("results", f"repaired_{k + 1}.owl")
+            self.builder.save(ttl_path, fmt="turtle")
+            self.builder.save(owl_path, fmt="xml")
+            if self.reason:
+                try:
+                    run_reasoner(owl_path)
+                except ReasonerError as exc:
+                    logger.warning("Reasoner failed: %s", exc)
+            current_data = ttl_path
+            k += 1
 
 
 def main():
@@ -62,7 +92,17 @@ def main():
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("Set OPENAI_API_KEY in .env for repair loop.")
-    repairer = RepairLoop(DATA_FILE, SHAPES_FILE, api_key)
+    kmax = int(os.getenv("REPAIR_KMAX", 5))
+    reason = os.getenv("REPAIR_REASON", "false").lower() == "true"
+    inference = os.getenv("REPAIR_INFERENCE", "rdfs")
+    repairer = RepairLoop(
+        DATA_FILE,
+        SHAPES_FILE,
+        api_key,
+        kmax=kmax,
+        reason=reason,
+        inference=inference,
+    )
     repairer.run()
 
 

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -21,9 +21,10 @@ def test_repair_loop_validates_twice(monkeypatch, tmp_path):
         instances = []
         runs = []
 
-        def __init__(self, data_path, shapes_path):
+        def __init__(self, data_path, shapes_path, inference="rdfs"):
             self.data_path = data_path
             self.shapes_path = shapes_path
+            self.inference = inference
             FakeValidator.instances.append(self)
 
         def run_validation(self):
@@ -38,4 +39,4 @@ def test_repair_loop_validates_twice(monkeypatch, tmp_path):
     repairer.run()
 
     assert len(FakeValidator.runs) == 2
-    assert FakeValidator.runs[1].endswith("results/repaired.ttl")
+    assert FakeValidator.runs[1].endswith("results/repaired_1.ttl")


### PR DESCRIPTION
## Summary
- extend `RepairLoop` to accept `kmax`, reasoning flag, and SHACL inference level
- implement iterative loop that validates, prompts LLM per violation, saves reports, and optionally runs reasoner
- expose new controls via environment variables and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d986c95883308b0a731ff69eecbf