### PR TITLE
Expose additional SHACL result details

### DIFF
--- a/ontology_guided/validator.py
+++ b/ontology_guided/validator.py
@@ -1,4 +1,5 @@
 from rdflib.namespace import RDF, SH
+from rdflib import URIRef
 from pyshacl import validate
 import os
 
@@ -26,11 +27,25 @@ class SHACLValidator:
                 focus = results_graph.value(result, SH.focusNode)
                 path = results_graph.value(result, SH.resultPath)
                 message = results_graph.value(result, SH.resultMessage)
+                source_shape = results_graph.value(result, SH.sourceShape)
+                severity = results_graph.value(result, SH.resultSeverity)
+                component = results_graph.value(
+                    result, SH.sourceConstraintComponent
+                )
+                expected = results_graph.value(result, URIRef(str(SH) + "expected"))
+                value = results_graph.value(result, SH.value)
                 results.append(
                     {
                         "focusNode": str(focus) if focus else None,
                         "resultPath": str(path) if path else None,
                         "message": str(message) if message else None,
+                        "sourceShape": str(source_shape) if source_shape else None,
+                        "resultSeverity": str(severity) if severity else None,
+                        "sourceConstraintComponent": str(component)
+                        if component
+                        else None,
+                        "expected": str(expected) if expected else None,
+                        "value": str(value) if value else None,
                     }
                 )
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -62,5 +62,18 @@ atm:atm1 a atm:ATM ;
     conforms, results = validator.run_validation()
     assert not conforms
     assert isinstance(results, list)
-    assert all({"focusNode", "resultPath", "message"} <= r.keys() for r in results)
+    assert all(
+        {
+            "focusNode",
+            "resultPath",
+            "message",
+            "sourceShape",
+            "resultSeverity",
+            "sourceConstraintComponent",
+            "expected",
+            "value",
+        }
+        <= r.keys()
+        for r in results
+    )
 


### PR DESCRIPTION
## Summary
- capture source shape, severity, constraint component, expected and value in validation output
- assert presence of new fields in validator tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc4adc748330b8d2b95100337b18