### PR TITLE
Track provenance of generated ontology triples

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -114,12 +114,13 @@ def run_pipeline(
                     snippets_preview.append(snippet)
                 snippet_counter += 1
                 try:
-                    builder.parse_turtle(
+                    triples = builder.parse_turtle(
                         snippet,
                         logger=logger,
                         requirement=sent,
                         snippet_index=snippet_counter,
                     )
+                    builder.add_provenance(sent, triples)
                 except InvalidTurtleError:
                     logger.warning(
                         "Skipping invalid OWL snippet for sentence: %s", sent
@@ -133,12 +134,13 @@ def run_pipeline(
                 snippets_preview.append(snippet)
             snippet_counter += 1
             try:
-                builder.parse_turtle(
+                triples = builder.parse_turtle(
                     snippet,
                     logger=logger,
                     requirement=sent,
                     snippet_index=snippet_counter,
                 )
+                builder.add_provenance(sent, triples)
             except InvalidTurtleError:
                 logger.warning(
                     "Skipping invalid OWL snippet for sentence: %s", sent
@@ -151,6 +153,7 @@ def run_pipeline(
     builder.save("results/combined.owl", fmt="xml")
     pipeline["combined_ttl"] = "results/combined.ttl"
     pipeline["combined_owl"] = "results/combined.owl"
+    pipeline["provenance"] = builder.triple_provenance
     logger.info("Saved results/combined.ttl and results/combined.owl")
 
     if reason:

--- a/tests/test_ontology_builder.py
+++ b/tests/test_ontology_builder.py
@@ -9,8 +9,10 @@ def test_parse_turtle_with_prefix():
     ob = OntologyBuilder('http://example.com/atm#')
     ttl = """@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."""
     logger = logging.getLogger(__name__)
-    ob.parse_turtle(ttl, logger=logger)
+    triples = ob.parse_turtle(ttl, logger=logger)
+    ob.add_provenance("req", triples)
     assert len(ob.graph) == 1
+    assert ob.triple_provenance
 
 
 def test_parse_turtle_bad_syntax():

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -27,6 +27,10 @@ def test_run_pipeline_custom_settings(monkeypatch, tmp_path):
     )
     assert result["shacl_conforms"] is True
     assert result["failed_snippets"] == []
+    assert any(
+        "The ATM must log" in entry["requirement"]
+        for entry in result["provenance"].values()
+    )
 
 
 def test_run_pipeline_collects_failed_snippets(monkeypatch, tmp_path):
@@ -56,6 +60,7 @@ def test_run_pipeline_collects_failed_snippets(monkeypatch, tmp_path):
             "snippet": "invalid turtle",
         }
     ]
+    assert result["provenance"] == {}
 
 
 def test_run_pipeline_ontology_dir(monkeypatch, tmp_path):
@@ -77,11 +82,15 @@ def test_run_pipeline_ontology_dir(monkeypatch, tmp_path):
     class FakeBuilder:
         def __init__(self, base_iri, ontology_files=None):
             captured["files"] = list(ontology_files or [])
+            self.triple_provenance = {}
 
         def get_available_terms(self):
             return []
 
         def parse_turtle(self, *args, **kwargs):
+            return []
+
+        def add_provenance(self, requirement, triples):
             pass
 
         def save(self, path, fmt):


### PR DESCRIPTION
## Summary
- Add provenance tracking to `OntologyBuilder` with `add_provenance` and internal triple→requirement mapping
- Record provenance during `run_pipeline` and expose it in the returned data structure
- Extend tests to cover provenance collection and pipeline output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ddb3c81c8330b7a365f354976046