### PR TITLE
Run reasoner before SHACL when requested

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -159,6 +159,15 @@ def run_pipeline(
     pipeline["provenance"] = builder.triple_provenance
     logger.info("Saved results/combined.ttl and results/combined.owl")
 
+    if reason:
+        try:
+            from ontology_guided.reasoner import run_reasoner
+
+            run_reasoner(pipeline["combined_owl"])
+            pipeline["reasoning_log"] = "Reasoner completed successfully"
+        except Exception as exc:  # pragma: no cover - log unexpected errors
+            pipeline["reasoning_log"] = str(exc)
+
     validator = SHACLValidator(pipeline["combined_ttl"], shapes, inference=inference)
     conforms, report = validator.run_validation()
     logger.info("Conforms: %s", conforms)


### PR DESCRIPTION
## Summary
- Invoke `run_reasoner` in `run_pipeline` when `reason=True` and log the outcome in `pipeline["reasoning_log"]`
- Add tests confirming the reasoner is triggered and its log captured

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e24f9fc88330be903ab821ff64ee