### PR TITLE
Return violations from repair loop

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -110,15 +110,17 @@ class RepairLoop:
 
     def run(
         self, *, reason: bool = False, inference: str = "rdfs"
-    ) -> Tuple[Optional[str], str]:
+    ) -> Tuple[Optional[str], str, List[dict]]:
         logger = logging.getLogger(__name__)
         os.makedirs("results", exist_ok=True)
         current_data = self.data_path
         report_path = ""
+        final_violations: List[dict] = []
         k = 0
         while True:
             validator = SHACLValidator(current_data, self.shapes_path, inference=inference)
             conforms, violations = validator.run_validation()
+            final_violations = violations
             report_path = os.path.join("results", f"report_{k}.txt")
             with open(report_path, "w", encoding="utf-8") as f:
                 if conforms:
@@ -182,7 +184,7 @@ class RepairLoop:
             current_data = ttl_path
             k += 1
 
-        return (current_data if k > 0 else None, report_path)
+        return (current_data if k > 0 else None, report_path, final_violations)
 
 
 def main():

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -178,10 +178,10 @@ def run_pipeline(
     if not conforms and repair:
         logger.info("Running repair loop...")
         repairer = RepairLoop(pipeline["combined_ttl"], shapes, api_key, kmax=kmax)
-        repaired_ttl, repaired_report = repairer.run(
+        repaired_ttl, repaired_report, violations = repairer.run(
             reason=reason, inference=inference
         )
-        pipeline["repaired_report"] = repaired_report
+        pipeline["repaired_report"] = {"path": repaired_report, "violations": violations}
         if repaired_ttl:
             pipeline["repaired_ttl"] = repaired_ttl
 

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -46,12 +46,13 @@ def test_repair_loop_validates_twice(monkeypatch, tmp_path):
     monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
 
     repairer = RepairLoop(str(data_path), str(shapes_path), api_key="dummy")
-    ttl_path, report_path = repairer.run()
+    ttl_path, report_path, violations = repairer.run()
 
     assert len(FakeValidator.runs) == 2
     assert FakeValidator.runs[1].endswith("results/repaired_1.ttl")
     assert ttl_path and ttl_path.endswith("results/repaired_1.ttl")
     assert report_path.endswith("results/report_1.txt")
+    assert violations == []
 
     report0 = tmp_path / "results" / "report_0.txt"
     content = report0.read_text(encoding="utf-8").strip()

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -142,7 +142,7 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
         def run(self, reason=False, inference="rdfs"):
             captured["reason"] = reason
             captured["inference"] = inference
-            return ("fixed.ttl", "final_report.txt")
+            return ("fixed.ttl", "final_report.txt", ["v1"])
 
     monkeypatch.setattr(main, "RepairLoop", FakeRepairLoop)
 
@@ -163,7 +163,8 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
 
     assert captured == {"kmax": 7, "reason": True, "inference": "owlrl"}
     assert result["repaired_ttl"] == "fixed.ttl"
-    assert result["repaired_report"] == "final_report.txt"
+    assert result["repaired_report"]["path"] == "final_report.txt"
+    assert result["repaired_report"]["violations"] == ["v1"]
 
 
 def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
@@ -189,7 +190,7 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
             pass
 
         def run(self, reason=False, inference="rdfs"):
-            return (None, "final_report.txt")
+            return (None, "final_report.txt", [])
 
     monkeypatch.setattr(main, "RepairLoop", FakeRepairLoop)
 
@@ -207,7 +208,8 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
     )
 
     assert "repaired_ttl" not in result
-    assert result["repaired_report"] == "final_report.txt"
+    assert result["repaired_report"]["path"] == "final_report.txt"
+    assert result["repaired_report"]["violations"] == []
 
 
 def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Make `RepairLoop.run` return the final report path and SHACL violations
- Save repair loop report and violations in `run_pipeline`
- Update tests for new repair loop return values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e6c0dc808330a3ac421927c8f620