### PR TITLE
Allow RepairLoop base IRI configuration

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -119,12 +119,14 @@ class RepairLoop:
         api_key: str,
         *,
         kmax: int = 5,
+        base_iri: str = BASE_IRI,
     ):
         self.data_path = data_path
         self.shapes_path = shapes_path
         self.kmax = kmax
         self.llm = LLMInterface(api_key=api_key)
-        self.builder = OntologyBuilder(BASE_IRI)
+        self.base_iri = base_iri
+        self.builder = OntologyBuilder(self.base_iri)
 
     def run(
         self, *, reason: bool = False, inference: str = "rdfs"
@@ -188,7 +190,7 @@ class RepairLoop:
             with open(current_data, "r", encoding="utf-8") as f:
                 original = f.read()
             merged = original + "\n\n" + "\n\n".join(repair_snippets)
-            self.builder = OntologyBuilder(BASE_IRI)
+            self.builder = OntologyBuilder(self.base_iri)
             self.builder.parse_turtle(merged, logger=logger)
             ttl_path = os.path.join("results", f"repaired_{k + 1}.ttl")
             owl_path = os.path.join("results", f"repaired_{k + 1}.owl")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -177,7 +177,9 @@ def run_pipeline(
 
     if not conforms and repair:
         logger.info("Running repair loop...")
-        repairer = RepairLoop(pipeline["combined_ttl"], shapes, api_key, kmax=kmax)
+        repairer = RepairLoop(
+            pipeline["combined_ttl"], shapes, api_key, kmax=kmax, base_iri=base_iri
+        )
         repaired_ttl, repaired_report, violations = repairer.run(
             reason=reason, inference=inference
         )

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -136,8 +136,9 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
     captured = {}
 
     class FakeRepairLoop:
-        def __init__(self, data_path, shapes_path, api_key, kmax=5):
+        def __init__(self, data_path, shapes_path, api_key, *, kmax=5, base_iri=None):
             captured["kmax"] = kmax
+            captured["base_iri"] = base_iri
 
         def run(self, reason=False, inference="rdfs"):
             captured["reason"] = reason
@@ -161,7 +162,12 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
         spacy_model="en",
     )
 
-    assert captured == {"kmax": 7, "reason": True, "inference": "owlrl"}
+    assert captured == {
+        "kmax": 7,
+        "reason": True,
+        "inference": "owlrl",
+        "base_iri": "http://example.com/atm#",
+    }
     assert result["repaired_ttl"] == "fixed.ttl"
     assert result["repaired_report"]["path"] == "final_report.txt"
     assert result["repaired_report"]["violations"] == ["v1"]
@@ -186,7 +192,7 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "SHACLValidator", FakeValidator)
 
     class FakeRepairLoop:
-        def __init__(self, data_path, shapes_path, api_key, kmax=5):
+        def __init__(self, data_path, shapes_path, api_key, *, kmax=5, base_iri=None):
             pass
 
         def run(self, reason=False, inference="rdfs"):


### PR DESCRIPTION
## Summary
- Allow configuring base IRI for `RepairLoop` and use it for ontology building
- Wire `scripts/main.py` to pass the base IRI into `RepairLoop`
- Adjust tests for new signature and verify base IRI is forwarded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6133f05cc83309c83b27ff55e9a7e