### PR TITLE
Log inconsistent OWL classes

### DIFF
--- a/ontology_guided/reasoner.py
+++ b/ontology_guided/reasoner.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import os
+import logging
 from owlready2 import get_ontology, sync_reasoner
 from owlready2.base import OwlReadyJavaError
+
+
+logger = logging.getLogger(__name__)
 
 
 class ReasonerError(RuntimeError):
@@ -20,17 +24,22 @@ def run_reasoner(owl_path: str = "results/combined.owl"):
 
     Returns
     -------
-    The loaded ontology after reasoning.
+    tuple
+        The loaded ontology and a list of IRIs for inconsistent classes.
     """
     if not os.path.exists(owl_path):
         raise FileNotFoundError(f"{owl_path} not found")
 
     onto = get_ontology("file://" + os.path.abspath(owl_path)).load()
+    inconsistent: list = []
     try:
         with onto:
             sync_reasoner()
+            inconsistent = list(onto.world.inconsistent_classes())
     except OwlReadyJavaError as exc:
         raise ReasonerError(
             "Java runtime not found; install Java to enable reasoning"
         ) from exc
-    return onto
+    for cls in inconsistent:
+        logger.warning("Inconsistent class: %s", cls.iri)
+    return onto, [c.iri for c in inconsistent]

--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -198,7 +198,13 @@ class RepairLoop:
             self.builder.save(owl_path, fmt="xml")
             if reason:
                 try:
-                    run_reasoner(owl_path)
+                    _, inconsistent = run_reasoner(owl_path)
+                    inc_path = os.path.join(
+                        "results", f"inconsistent_classes_{k + 1}.txt"
+                    )
+                    with open(inc_path, "w", encoding="utf-8") as f:
+                        for iri in inconsistent:
+                            f.write(iri + "\n")
                 except ReasonerError as exc:
                     logger.warning("Reasoner failed: %s", exc)
             current_data = ttl_path

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -164,8 +164,16 @@ def run_pipeline(
         try:
             from ontology_guided.reasoner import run_reasoner
 
-            run_reasoner(pipeline["combined_owl"])
+            _, inconsistent = run_reasoner(pipeline["combined_owl"])
+            inconsistent_path = os.path.join("results", "inconsistent_classes.txt")
+            with open(inconsistent_path, "w", encoding="utf-8") as f:
+                for iri in inconsistent:
+                    f.write(iri + "\n")
             pipeline["reasoning_log"] = "Reasoner completed successfully"
+            pipeline["inconsistent_classes"] = {
+                "path": inconsistent_path,
+                "iris": inconsistent,
+            }
         except Exception as exc:  # pragma: no cover - log unexpected errors
             pipeline["reasoning_log"] = str(exc)
 

--- a/tests/test_reasoner.py
+++ b/tests/test_reasoner.py
@@ -16,10 +16,11 @@ def test_run_reasoner(tmp_path):
     onto.save(file=str(owl_path))
 
     try:
-        result = run_reasoner(str(owl_path))
+        result, inconsistent = run_reasoner(str(owl_path))
     except ReasonerError as exc:
         pytest.skip(str(exc))
         return
 
+    assert inconsistent == []
     names = {c.name for c in result.classes()}
     assert {"A", "B"}.issubset(names)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -231,6 +231,7 @@ def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):
 
     def fake_run_reasoner(path):
         called["path"] = path
+        return None, []
 
     import ontology_guided.reasoner as reasoner
 
@@ -251,3 +252,5 @@ def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):
 
     assert called["path"].endswith("combined.owl")
     assert result["reasoning_log"] == "Reasoner completed successfully"
+    assert result["inconsistent_classes"]["iris"] == []
+    assert pathlib.Path(result["inconsistent_classes"]["path"]).exists()


### PR DESCRIPTION
## Summary
- Collect and log unsatisfiable class IRIs after reasoning
- Expose inconsistent classes to callers and persist them under `results/`
- Update pipeline and repair loop to write inconsistency reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a626c194588330beb037c022628379