### PR TITLE
Expose ontology prompts with domain hints and synonyms

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -115,17 +115,18 @@ def canonicalize_violation(violation: dict) -> str:
 
 
 def map_to_ontology_terms(
-    available_terms: Tuple[List[str], List[str]], context: str
+    available_terms: Dict[str, List[str]], context: str
 ) -> Tuple[List[str], List[str]]:
     """Select ontology terms mentioned in the context."""
-    classes, properties = available_terms
+    classes = available_terms.get("classes", [])
+    properties = available_terms.get("properties", [])
     class_hits = [c for c in classes if c in context]
     property_hits = [p for p in properties if p in context]
     return class_hits, property_hits
 
 
 def synthesize_repair_prompts(
-    violations, graph: Graph, available_terms: Tuple[List[str], List[str]]
+    violations, graph: Graph, available_terms: Dict[str, List[str]]
 ) -> List[str]:
     """Construct prompts for the LLM based on violations and context."""
     prompts: List[str] = []
@@ -215,7 +216,12 @@ class RepairLoop:
                     for s in graph.subjects(RDF.type, OWL.DatatypeProperty)
                 }
             )
-            available_terms = (classes, properties)
+            available_terms = {
+                "classes": classes,
+                "properties": properties,
+                "domain_range_hints": {},
+                "synonyms": {},
+            }
 
             prompts = synthesize_repair_prompts(violations, graph, available_terms)
             repair_snippets = []

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -148,9 +148,17 @@ def test_generate_owl_with_terms(monkeypatch, tmp_path):
     monkeypatch.setattr(openai.chat.completions, "create", fake_create)
 
     llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
-    llm.generate_owl(["irrelevant"], "{sentence}", available_terms=(['ex:Class'], ['ex:prop']))
+    terms = {
+        "classes": ["ex:Class"],
+        "properties": ["ex:prop"],
+        "domain_range_hints": {"ex:prop": {"domain": ["ex:A"], "range": ["ex:B"]}},
+        "synonyms": {"ex:quick": "ex:fast"},
+    }
+    llm.generate_owl(["irrelevant"], "{sentence}", available_terms=terms)
     assert 'ex:Class' in captured['prompt']
     assert 'ex:prop' in captured['prompt']
+    assert 'domain ex:A' in captured['prompt']
+    assert 'ex:quick -> ex:fast' in captured['prompt']
 
 
 def test_generate_owl_uses_cache(monkeypatch, tmp_path):

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -85,7 +85,7 @@ def test_run_pipeline_ontology_dir(monkeypatch, tmp_path):
             self.triple_provenance = {}
 
         def get_available_terms(self):
-            return []
+            return {"classes": [], "properties": [], "domain_range_hints": {}, "synonyms": {}}
 
         def parse_turtle(self, *args, **kwargs):
             return []


### PR DESCRIPTION
## Summary
- Extract property domain/range hints and synonym mappings from ontologies
- Provide structured term info including classes, properties, hints, and synonyms
- Integrate hints and synonyms into LLM prompts and repair loop helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a62a602d0c8330aa9ad065b06c8711