### PR TITLE
Add OG-NSD pipeline diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Ontology-Guided/
 ```
 
 ---
+## 🔄 OG‑NSD Pipeline
+
+![OG‑NSD Pipeline](docs/pipeline.svg)
+
+---
 ## 🗺️ Διάγραμμα Ροής Δεδομένων
 
 ![Data Flow Diagram](docs/dfd.png)

--- a/docs/pipeline.svg
+++ b/docs/pipeline.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="240" viewBox="0 0 1200 240" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <style>
+      .neural { fill: #f9cb9c; }
+      .symbolic { fill: #9fc5e8; }
+      .hybrid { fill: #b6d7a8; }
+      .io { fill: #eeeeee; }
+      .box { stroke: #000; stroke-width: 1; }
+      .arrow { fill: none; stroke: #000; stroke-width: 2; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+
+  <!-- Legend -->
+  <rect class="neural box" x="20" y="20" width="20" height="20"/>
+  <text x="45" y="35">Neural</text>
+  <rect class="symbolic box" x="120" y="20" width="20" height="20"/>
+  <text x="145" y="35">Symbolic</text>
+  <rect class="hybrid box" x="230" y="20" width="20" height="20"/>
+  <text x="255" y="35">Hybrid</text>
+
+  <!-- Nodes -->
+  <rect class="io box" x="20" y="100" width="100" height="40" />
+  <text x="70" y="125" text-anchor="middle">Inputs</text>
+
+  <rect class="symbolic box" x="150" y="100" width="140" height="40" />
+  <text x="220" y="125" text-anchor="middle">Load requirements</text>
+
+  <rect class="neural box" x="320" y="100" width="140" height="40" />
+  <text x="390" y="125" text-anchor="middle">Generate OWL</text>
+
+  <rect class="symbolic box" x="490" y="100" width="140" height="40" />
+  <text x="560" y="125" text-anchor="middle">Build ontology</text>
+
+  <rect class="symbolic box" x="660" y="100" width="140" height="40" />
+  <text x="730" y="125" text-anchor="middle">Run reasoner</text>
+
+  <rect class="symbolic box" x="830" y="100" width="140" height="40" />
+  <text x="900" y="125" text-anchor="middle">Validate SHACL</text>
+
+  <rect class="hybrid box" x="1000" y="60" width="140" height="40" />
+  <text x="1070" y="85" text-anchor="middle">Repair loop</text>
+
+  <rect class="io box" x="1000" y="160" width="140" height="40" />
+  <text x="1070" y="185" text-anchor="middle">Outputs</text>
+
+  <!-- Arrows -->
+  <line class="arrow" x1="120" y1="120" x2="150" y2="120" />
+  <line class="arrow" x1="290" y1="120" x2="320" y2="120" />
+  <line class="arrow" x1="460" y1="120" x2="490" y2="120" />
+  <line class="arrow" x1="630" y1="120" x2="660" y2="120" />
+  <line class="arrow" x1="800" y1="120" x2="830" y2="120" />
+  <line class="arrow" x1="970" y1="120" x2="1000" y2="80" />
+  <line class="arrow" x1="1070" y1="100" x2="1070" y2="160" />
+  <path class="arrow" d="M1000 80 L1000 60 L830 60 L830 100" />
+  <line class="arrow" x1="970" y1="120" x2="1000" y2="180" />
+</svg>


### PR DESCRIPTION
## Summary
- add color-coded OG-NSD pipeline diagram showing neural, symbolic, and hybrid stages
- embed the new pipeline figure in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62e6a37548330bf80d1b19a028e33