### PR TITLE
Add repair loop diagram and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Ontology-Guided/
 
 ![OG‑NSD Pipeline](docs/pipeline.svg)
 
+## ♻️ Repair Loop
+
+![Repair Loop](docs/repair_loop_zoom.svg)
+
 ---
 ## 🗺️ Διάγραμμα Ροής Δεδομένων
 

--- a/docs/repair_loop_zoom.mmd
+++ b/docs/repair_loop_zoom.mmd
@@ -1,0 +1,5 @@
+graph LR
+    A[Real violation]:::symbolic --> B[Repair prompt]:::neural --> C[Corrected axioms diff]:::symbolic
+    classDef neural fill:#f9cb9c,stroke:#000,stroke-width:1;
+    classDef symbolic fill:#9fc5e8,stroke:#000,stroke-width:1;
+    classDef hybrid fill:#b6d7a8,stroke:#000,stroke-width:1;

--- a/docs/repair_loop_zoom.svg
+++ b/docs/repair_loop_zoom.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="160" viewBox="0 0 700 160" font-family="Arial, Helvetica, sans-serif">
+  <defs>
+    <style>
+      .neural { fill: #f9cb9c; }
+      .symbolic { fill: #9fc5e8; }
+      .hybrid { fill: #b6d7a8; }
+      .box { stroke: #000; stroke-width: 1; }
+      .arrow { fill: none; stroke: #000; stroke-width: 2; marker-end: url(#arrowhead); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" />
+    </marker>
+  </defs>
+
+  <!-- Legend -->
+  <rect class="neural box" x="20" y="20" width="20" height="20"/>
+  <text x="45" y="35">Neural</text>
+  <rect class="symbolic box" x="120" y="20" width="20" height="20"/>
+  <text x="145" y="35">Symbolic</text>
+  <rect class="hybrid box" x="230" y="20" width="20" height="20"/>
+  <text x="255" y="35">Hybrid</text>
+
+  <!-- Nodes -->
+  <rect class="symbolic box" x="20" y="80" width="180" height="40"/>
+  <text x="110" y="105" text-anchor="middle">Real violation</text>
+
+  <rect class="neural box" x="260" y="80" width="180" height="40"/>
+  <text x="350" y="105" text-anchor="middle">Repair prompt</text>
+
+  <rect class="symbolic box" x="500" y="80" width="180" height="40"/>
+  <text x="590" y="105" text-anchor="middle">Corrected axioms diff</text>
+
+  <!-- Arrows -->
+  <line class="arrow" x1="200" y1="100" x2="260" y2="100"/>
+  <line class="arrow" x1="440" y1="100" x2="500" y2="100"/>
+</svg>


### PR DESCRIPTION
## Summary
- add repair loop zoom diagram with neural/symbolic color coding
- document repair loop figure in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66dd8b8ec8330b1f1ac3e38328f91