### PR TITLE
Track SHACL violation statistics in repair loop

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -170,9 +170,12 @@ class RepairLoop:
         report_path = ""
         final_violations: List[dict] = []
         k = 0
+        initial_count = 0
         while True:
             validator = SHACLValidator(current_data, self.shapes_path, inference=inference)
             conforms, violations = validator.run_validation()
+            if k == 0:
+                initial_count = len(violations)
             final_violations = violations
             report_path = os.path.join("results", f"report_{k}.txt")
             with open(report_path, "w", encoding="utf-8") as f:
@@ -262,7 +265,18 @@ class RepairLoop:
             current_data = ttl_path
             k += 1
 
-        return (current_data if k > 0 else None, report_path, final_violations)
+        stats = {
+            "initial_count": initial_count,
+            "final_count": len(final_violations),
+            "iterations": k,
+        }
+
+        return (
+            current_data if k > 0 else None,
+            report_path,
+            final_violations,
+            stats,
+        )
 
 
 def main():

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -198,10 +198,11 @@ def run_pipeline(
             repairer = RepairLoop(
                 pipeline["combined_ttl"], shapes, api_key, kmax=kmax, base_iri=base_iri
             )
-            repaired_ttl, repaired_report, violations = repairer.run(
+            repaired_ttl, repaired_report, violations, stats = repairer.run(
                 reason=reason, inference=inference
             )
             pipeline["repaired_report"] = {"path": repaired_report, "violations": violations}
+            pipeline["violation_stats"] = stats
             if repaired_ttl:
                 pipeline["repaired_ttl"] = repaired_ttl
     else:

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -47,13 +47,14 @@ def test_repair_loop_validates_twice(monkeypatch, tmp_path):
     monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
 
     repairer = RepairLoop(str(data_path), str(shapes_path), api_key="dummy")
-    ttl_path, report_path, violations = repairer.run()
+    ttl_path, report_path, violations, stats = repairer.run()
 
     assert len(FakeValidator.runs) == 2
     assert FakeValidator.runs[1].endswith("results/repaired_1.ttl")
     assert ttl_path and ttl_path.endswith("results/repaired_1.ttl")
     assert report_path.endswith("results/report_1.txt")
     assert violations == []
+    assert stats == {"initial_count": 1, "final_count": 0, "iterations": 1}
 
     report0 = tmp_path / "results" / "report_0.txt"
     content = report0.read_text(encoding="utf-8").strip()

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -143,7 +143,12 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
         def run(self, reason=False, inference="rdfs"):
             captured["reason"] = reason
             captured["inference"] = inference
-            return ("fixed.ttl", "final_report.txt", ["v1"])
+            return (
+                "fixed.ttl",
+                "final_report.txt",
+                ["v1"],
+                {"initial_count": 1, "final_count": 0, "iterations": 1},
+            )
 
     monkeypatch.setattr(main, "RepairLoop", FakeRepairLoop)
 
@@ -171,6 +176,11 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
     assert result["repaired_ttl"] == "fixed.ttl"
     assert result["repaired_report"]["path"] == "final_report.txt"
     assert result["repaired_report"]["violations"] == ["v1"]
+    assert result["violation_stats"] == {
+        "initial_count": 1,
+        "final_count": 0,
+        "iterations": 1,
+    }
 
 
 def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
@@ -196,7 +206,12 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
             pass
 
         def run(self, reason=False, inference="rdfs"):
-            return (None, "final_report.txt", [])
+            return (
+                None,
+                "final_report.txt",
+                [],
+                {"initial_count": 0, "final_count": 0, "iterations": 0},
+            )
 
     monkeypatch.setattr(main, "RepairLoop", FakeRepairLoop)
 
@@ -216,6 +231,11 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
     assert "repaired_ttl" not in result
     assert result["repaired_report"]["path"] == "final_report.txt"
     assert result["repaired_report"]["violations"] == []
+    assert result["violation_stats"] == {
+        "initial_count": 0,
+        "final_count": 0,
+        "iterations": 0,
+    }
 
 
 def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Record initial and final SHACL violation counts and iteration count within `RepairLoop.run`
- Return violation stats and expose them via `run_pipeline` in `pipeline['violation_stats']`
- Update tests for new return signature and stats handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6aee6cc1c833096407aa5e66c621f