### PR TITLE
Refresh term vocabulary after parsing snippets

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -129,6 +129,8 @@ def run_pipeline(
                         snippet_index=snippet_counter,
                     )
                     builder.add_provenance(sent, triples)
+                    if use_terms:
+                        avail_terms = builder.get_available_terms()
                 except InvalidTurtleError:
                     logger.warning(
                         "Skipping invalid OWL snippet for sentence: %s", sent
@@ -149,6 +151,8 @@ def run_pipeline(
                     snippet_index=snippet_counter,
                 )
                 builder.add_provenance(sent, triples)
+                if use_terms:
+                    avail_terms = builder.get_available_terms()
             except InvalidTurtleError:
                 logger.warning(
                     "Skipping invalid OWL snippet for sentence: %s", sent


### PR DESCRIPTION
## Summary
- Refresh available ontology terms after each parsed snippet so subsequent LLM batches see newly introduced terms.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76b747f74833091b5dc2bd7610efa