### PR TITLE
Use OntologyBuilder for available terms in repair loop

### DIFF
--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -85,7 +85,17 @@ def test_synthesize_repair_prompts_returns_structured_json(monkeypatch):
             "value": "http://example.com/b",
         }
     ]
-    available_terms = {"classes": [], "properties": []}
+    available_terms = {
+        "classes": [],
+        "properties": [],
+        "domain_range_hints": {
+            "http://example.com/p": {
+                "domain": ["http://example.com/A"],
+                "range": ["http://example.com/B"],
+            }
+        },
+        "synonyms": {"http://example.com/alias": "http://example.com/A"},
+    }
 
     monkeypatch.setattr(
         repair_loop,
@@ -106,6 +116,10 @@ def test_synthesize_repair_prompts_returns_structured_json(monkeypatch):
         "http://example.com/a http://example.com/p http://example.com/b"
     ]
     assert "http://example.com/p" in prompt["terms"]
+    assert prompt["domain_range_hints"]["http://example.com/p"]["domain"] == [
+        "http://example.com/A"
+    ]
+    assert prompt["synonyms"]["http://example.com/alias"] == "http://example.com/A"
     assert prompt["reasoner_inconsistencies"] == [
         "http://example.com/BadClass"
     ]


### PR DESCRIPTION
## Summary
- Build ontology metadata from current data using `OntologyBuilder` instead of manual class/property scans
- Include domain/range hints and synonym maps in repair prompts and feed them to the LLM
- Extend tests to verify repair prompts contain new ontology guidance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76e2de2d88330a6e99e26ad2a7ad8