### PR TITLE
Add healthcare domain artefacts and cross-domain regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,24 @@ python3 scripts/generate_dfd.py
 - **ontologies/rbo.ttl**: ορίζει βασικές κλάσεις για Requirements, Actions και Actors, μαζί με τις ιδιότητες `requiresAction` και `performedBy`.
 - **ontologies/lexical.ttl**: περιέχει λεξική δομή με κλάσεις `Word`, `Noun` και σχέσεις `synonym`, `antonym` μεταξύ λέξεων.
 
+## 🏥 Εναλλαγή Τομέων
+
+Η ίδια διαδικασία μπορεί να στραφεί σε διαφορετικό domain αλλάζοντας απλώς
+τις απαιτήσεις, τα SHACL shapes και τις (προαιρετικές) οντολογίες. Για
+παράδειγμα, το παρακάτω command εκτελεί το pipeline σε σενάριο υγείας χωρίς
+καμία επανεκπαίδευση του μοντέλου:
+
+```bash
+python3 scripts/main.py \
+    --inputs evaluation/healthcare_requirements.txt \
+    --shapes evaluation/healthcare_shapes.ttl \
+    --ontologies ontologies/healthcare.ttl \
+    --base-iri http://example.com/healthcare#
+```
+
+Το αποτέλεσμα είναι μια οντολογία με κανόνες για γιατρούς, ασθενείς και
+ιατρικές παρατηρήσεις.
+
 ## 📊 Αξιολόγηση
 
 Για να συγκρίνετε τα παραγόμενα OWL triples με ένα χρυσό πρότυπο, χρησιμοποιήστε το script:

--- a/evaluation/healthcare_requirements.txt
+++ b/evaluation/healthcare_requirements.txt
@@ -1,0 +1,2 @@
+Each patient observation must record the doctor performing the observation.
+The system shall link observations to the patient being examined.

--- a/evaluation/healthcare_shapes.ttl
+++ b/evaluation/healthcare_shapes.ttl
@@ -1,0 +1,16 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix hc: <http://example.com/healthcare#> .
+
+hc:ObservationShape
+    a sh:NodeShape ;
+    sh:targetClass hc:Observation ;
+    sh:property [
+        sh:path hc:performedBy ;
+        sh:minCount 1 ;
+        sh:class hc:Doctor ;
+    ] ;
+    sh:property [
+        sh:path hc:onPatient ;
+        sh:minCount 1 ;
+        sh:class hc:Patient ;
+    ] .

--- a/ontologies/healthcare.ttl
+++ b/ontologies/healthcare.ttl
@@ -1,0 +1,15 @@
+@prefix hc: <http://example.com/healthcare#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+hc:Patient a owl:Class .
+hc:Doctor a owl:Class .
+hc:Observation a owl:Class .
+
+hc:performedBy a owl:ObjectProperty ;
+    rdfs:domain hc:Observation ;
+    rdfs:range hc:Doctor .
+
+hc:onPatient a owl:ObjectProperty ;
+    rdfs:domain hc:Observation ;
+    rdfs:range hc:Patient .

--- a/tests/test_healthcare_switch.py
+++ b/tests/test_healthcare_switch.py
@@ -1,0 +1,42 @@
+import pathlib
+
+from scripts.main import run_pipeline
+from ontology_guided.llm_interface import LLMInterface
+
+
+def test_pipeline_switches_to_healthcare(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.chdir(tmp_path)
+
+    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+        return [
+            "@prefix hc: <http://example.com/healthcare#> .\n"
+            "hc:obs1 a hc:Observation ;\n"
+            "    hc:performedBy hc:doc1 ;\n"
+            "    hc:onPatient hc:pat1 .\n"
+            "hc:doc1 a hc:Doctor .\n"
+            "hc:pat1 a hc:Patient ."
+        ]
+
+    monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    inputs = [str(root / "evaluation" / "healthcare_requirements.txt")]
+    shapes = str(root / "evaluation" / "healthcare_shapes.ttl")
+    ontology = str(root / "ontologies" / "healthcare.ttl")
+
+    result = run_pipeline(
+        inputs,
+        shapes,
+        "http://example.com/healthcare#",
+        ontologies=[ontology],
+        spacy_model="en",
+        inference="none",
+    )
+
+    assert result["shacl_conforms"] is True
+    assert result["failed_snippets"] == []
+    assert any(
+        "patient observation" in entry["requirement"].lower()
+        for entry in result["provenance"].values()
+    )


### PR DESCRIPTION
## Summary
- Add healthcare-specific requirements, SHACL shapes, and optional ontology
- Document switching domains in README
- Test pipeline can run on healthcare domain without retraining

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76f92e6008330bd842c5f83a516d8