### PR TITLE
Add general ATM requirement for transaction logging

### DIFF
--- a/evaluation/atm_requirements.txt
+++ b/evaluation/atm_requirements.txt
@@ -1,2 +1,3 @@
-The ATM shall dispense cash when the PIN is correct.
+The ATM shall log all user transactions after card insertion.
 The ATM shall retain the card after three failed PIN attempts.
+The ATM shall dispense cash when the PIN is correct.


### PR DESCRIPTION
## Summary
- add missing general ATM requirement to the ATM evaluation dataset
- list requirements in clear "The ATM shall" format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77a0655fc833085954d0134b2c4b8