### PR TITLE
Ensure evaluation scripts locate project root

### DIFF
--- a/evaluation/compare_metrics.py
+++ b/evaluation/compare_metrics.py
@@ -2,6 +2,11 @@ import argparse
 from pathlib import Path
 from rdflib import Graph
 
+import os, sys
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from scripts.main import run_pipeline
 
 

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -26,6 +26,11 @@ from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
 from rdflib import Graph
 
+import os, sys
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from scripts.main import run_pipeline
 
 


### PR DESCRIPTION
## Summary
- Add project root path insertion to `evaluation/compare_metrics.py` and `evaluation/run_benchmark.py`
- Enables importing `scripts.main` when running these scripts directly

## Testing
- `pytest`
- `python evaluation/compare_metrics.py evaluation/atm_requirements.txt evaluation/atm_gold.ttl` *(fails: RuntimeError: Set OPENAI_API_KEY in .env)*
- `python evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" --base-iri http://lod.csd.auth.gr/atm/atm.ttl# --repeats 1` *(fails: RuntimeError: Set OPENAI_API_KEY in .env)*

------
https://chatgpt.com/codex/tasks/task_e_68a99a31c5388330a2378dc7ceac59a8