### PR TITLE
Raise error when LLM call fails

### DIFF
--- a/ontology_guided/llm_interface.py
+++ b/ontology_guided/llm_interface.py
@@ -129,8 +129,12 @@ class LLMInterface:
                     attempts += 1
                     self.logger.warning("LLM call failed: %s", e)
                     if attempts > max_retries:
-                        self.logger.error("Exiting gracefully.")
-                        return results
+                        self.logger.error(
+                            "LLM call failed after %d retries", max_retries
+                        )
+                        raise RuntimeError(
+                            f"LLM call failed after {max_retries} retries"
+                        ) from e
                     time.sleep(current_delay)
                     current_delay = min(current_delay * 2, max_retry_delay)
                     continue

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -261,23 +261,27 @@ def main():
     )
     args = parser.parse_args()
 
-    run_pipeline(
-        args.inputs,
-        args.shapes,
-        args.base_iri,
-        ontologies=args.ontologies,
-        ontology_dir=args.ontology_dir,
-        model=args.model,
-        repair=args.repair,
-        kmax=args.kmax,
-        reason=args.reason,
-        spacy_model=args.spacy_model,
-        inference=args.inference,
-        load_rbo=args.rbo,
-        load_lexical=args.lexical,
-        use_terms=not args.no_terms,
-        validate=not args.no_shacl,
-    )
+    try:
+        run_pipeline(
+            args.inputs,
+            args.shapes,
+            args.base_iri,
+            ontologies=args.ontologies,
+            ontology_dir=args.ontology_dir,
+            model=args.model,
+            repair=args.repair,
+            kmax=args.kmax,
+            reason=args.reason,
+            spacy_model=args.spacy_model,
+            inference=args.inference,
+            load_rbo=args.rbo,
+            load_lexical=args.lexical,
+            use_terms=not args.no_terms,
+            validate=not args.no_shacl,
+        )
+    except RuntimeError as exc:
+        logging.getLogger(__name__).error("Pipeline aborted: %s", exc)
+        raise SystemExit(1)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -75,18 +75,17 @@ def test_generate_owl_exit_on_error(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(time, "sleep", fake_sleep)
 
     llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
-    with caplog.at_level(logging.WARNING):
-        result = llm.generate_owl(
+    with caplog.at_level(logging.WARNING), pytest.raises(RuntimeError) as excinfo:
+        llm.generate_owl(
             ["irrelevant"],
             "{sentence}",
             max_retries=3,
             retry_delay=1,
             max_retry_delay=2,
         )
-    assert result == []
     assert sleep_calls == [1, 2, 2]
     assert "LLM call failed" in caplog.text
-    assert "Exiting gracefully." in caplog.text
+    assert "after 3 retries" in str(excinfo.value)
 
 
 def test_generate_owl_retry_then_success(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## Summary
- Raise `RuntimeError` when LLM requests exceed retry limit
- Abort pipeline gracefully in `scripts/main.py` when runtime errors occur
- Test that API failures propagate as exceptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99ebdc25083309890e30cfcb81032