### PR TITLE
Add base IRI normalization option to benchmark evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:eva
 Το script εκτελεί το pipeline με όλους τους συνδυασμούς των σημαιών `use_terms` και `validate`,
 αποθηκεύοντας τα αποτελέσματα σε πίνακες `table_<N>.csv` και `table_<N>.md` στον φάκελο `evaluation`.
 
+Η προαιρετική σημαία `--normalize-base` κανονικοποιεί τα base IRIs πριν τη σύγκριση,
+μειώνοντας ψευδείς αποκλίσεις όταν οι ίδιες τριπλέτες χρησιμοποιούν διαφορετικά base.
+
 Παράδειγμα με προσαρμοσμένη ρύθμιση που φορτώνει επιπλέον οντολογίες:
 
 ```bash

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -3,6 +3,7 @@ import pytest
 
 from evaluation.compare_metrics import compare_metrics
 from ontology_guided.llm_interface import LLMInterface
+from evaluation.run_benchmark import compute_metrics
 
 
 def test_compare_metrics(monkeypatch, tmp_path):
@@ -30,3 +31,26 @@ def test_compare_metrics(monkeypatch, tmp_path):
     metrics = compare_metrics(str(requirements), str(gold), str(shapes))
     assert metrics["precision"] == pytest.approx(1.0)
     assert metrics["recall"] == pytest.approx(0.001310615989515072)
+
+
+def test_compute_metrics_normalize_base(tmp_path):
+    pred = tmp_path / "pred.ttl"
+    pred.write_text(
+        "@prefix : <http://example.org/a#> .\n" \
+        ":x :p :y .\n",
+        encoding="utf-8",
+    )
+    gold = tmp_path / "gold.ttl"
+    gold.write_text(
+        "@prefix : <http://other.org/b#> .\n" \
+        ":x :p :y .\n",
+        encoding="utf-8",
+    )
+
+    no_norm = compute_metrics(str(pred), str(gold))
+    assert no_norm["precision"] == 0.0
+    assert no_norm["recall"] == 0.0
+
+    with_norm = compute_metrics(str(pred), str(gold), normalize_base=True)
+    assert with_norm["precision"] == 1.0
+    assert with_norm["recall"] == 1.0


### PR DESCRIPTION
## Summary
- Add helper to normalize base IRIs before comparing RDF graphs
- Expose optional `--normalize-base` flag for evaluation script
- Document normalization option and add tests for differing base IRIs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a99f5746ac8330adf651710815df6d