### PR TITLE
Add ATM domain ontology

### DIFF
--- a/ontologies/atm_domain.ttl
+++ b/ontologies/atm_domain.ttl
@@ -1,0 +1,26 @@
+@prefix : <http://lod.csd.auth.gr/atm/atm.ttl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:ATM a owl:Class .
+:Bank a owl:Class .
+:CashCard a owl:Class .
+:Customer a owl:Class .
+:Account a owl:Class .
+
+:ownsCard a owl:ObjectProperty ;
+    rdfs:domain :Customer ;
+    rdfs:range :CashCard .
+
+:belongsToBank a owl:ObjectProperty ;
+    rdfs:domain :ATM ;
+    rdfs:range :Bank .
+
+:hasAccount a owl:ObjectProperty ;
+    rdfs:domain :Customer ;
+    rdfs:range :Account .
+
+:cardIssuedBy a owl:ObjectProperty ;
+    rdfs:domain :CashCard ;
+    rdfs:range :Bank .


### PR DESCRIPTION
## Summary
- add ATM domain ontology with classes for ATM, Bank, CashCard, Customer and related properties

## Testing
- `pytest`
- `python evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" --repeats 1 --ontologies ontologies/atm_domain.ttl` *(fails: Set OPENAI_API_KEY in .env)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a3327c7c8330aabcd71308bfd838