### PR TITLE
Add ATM lexical ontology with synonym mappings

### DIFF
--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -251,9 +251,13 @@ def main() -> None:  # pragma: no cover - CLI wrapper
             {"name": "table4", "use_terms": False, "validate": False},
         ]
 
-    if args.ontologies:
-        for setting in settings_list:
-            setting.setdefault("ontologies", args.ontologies)
+    ontology_list = args.ontologies or [
+        "ontologies/atm_domain.ttl",
+        "ontologies/lexical.ttl",
+        "ontologies/lexical_atm.ttl",
+    ]
+    for setting in settings_list:
+        setting.setdefault("ontologies", ontology_list)
 
     run_evaluations(
         pairs,

--- a/ontologies/lexical_atm.ttl
+++ b/ontologies/lexical_atm.ttl
@@ -1,0 +1,17 @@
+@prefix lex: <http://example.com/lexical#> .
+@prefix : <http://lod.csd.auth.gr/atm/atm.ttl#> .
+
+lex:AutomatedTellerMachine a lex:Word ;
+    lex:synonym :ATM .
+
+lex:BankCard a lex:Word ;
+    lex:synonym :CashCard .
+
+lex:BankCustomer a lex:Word ;
+    lex:synonym :Customer .
+
+lex:BankAccount a lex:Word ;
+    lex:synonym :Account .
+
+lex:FinancialInstitution a lex:Word ;
+    lex:synonym :Bank .


### PR DESCRIPTION
## Summary
- add ATM-specific lexical ontology mapping domain classes to alternative terms
- load ATM domain and lexical ontologies by default during benchmark evaluation

## Testing
- `OPENAI_API_KEY=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a3f714348330982bb21b0192170c