### PR TITLE
feat: allow loading ontologies directory in benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,11 @@ python3 scripts/generate_dfd.py
 python3 scripts/main.py \
     --inputs evaluation/healthcare_requirements.txt \
     --shapes evaluation/healthcare_shapes.ttl \
-    --ontologies ontologies/healthcare.ttl \
+    --ontology-dir ontologies/healthcare \
     --base-iri http://example.com/healthcare#
 ```
 
+Εναλλακτικά, περάστε συγκεκριμένα αρχεία με `--ontologies`.
 Το αποτέλεσμα είναι μια οντολογία με κανόνες για γιατρούς, ασθενείς και
 ιατρικές παρατηρήσεις.
 
@@ -179,6 +180,17 @@ python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:eva
 
 Η προαιρετική σημαία `--normalize-base` κανονικοποιεί τα base IRIs πριν τη σύγκριση,
 μειώνοντας ψευδείς αποκλίσεις όταν οι ίδιες τριπλέτες χρησιμοποιούν διαφορετικά base.
+
+Οι οντολογίες ανά domain καθορίζονται εύκολα μέσω `--ontologies` για
+μεμονωμένα αρχεία ή `--ontology-dir` για φόρτωση όλων των `.ttl` από έναν
+φάκελο. Παράδειγμα:
+
+```bash
+python3 evaluation/run_benchmark.py \
+    --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" \
+    --ontology-dir ontologies \
+    --repeats 1
+```
 
 Παράδειγμα με προσαρμοσμένη ρύθμιση που φορτώνει επιπλέον οντολογίες:
 

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -233,6 +233,11 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         help="List of ontology TTL files to include in each run",
     )
     parser.add_argument(
+        "--ontology-dir",
+        default=None,
+        help="Directory from which all .ttl ontologies will be loaded",
+    )
+    parser.add_argument(
         "--normalize-base",
         action="store_true",
         help="Normalize base IRIs before comparing graphs",
@@ -251,11 +256,16 @@ def main() -> None:  # pragma: no cover - CLI wrapper
             {"name": "table4", "use_terms": False, "validate": False},
         ]
 
-    ontology_list = args.ontologies or [
-        "ontologies/atm_domain.ttl",
-        "ontologies/lexical.ttl",
-        "ontologies/lexical_atm.ttl",
-    ]
+    ontology_list = list(args.ontologies or [])
+    if args.ontology_dir:
+        dir_path = Path(args.ontology_dir)
+        ontology_list.extend(str(p) for p in sorted(dir_path.glob("*.ttl")))
+    if not ontology_list:
+        ontology_list = [
+            "ontologies/atm_domain.ttl",
+            "ontologies/lexical.ttl",
+            "ontologies/lexical_atm.ttl",
+        ]
     for setting in settings_list:
         setting.setdefault("ontologies", ontology_list)
 

--- a/tests/test_run_benchmark_cli.py
+++ b/tests/test_run_benchmark_cli.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+import evaluation.run_benchmark as rb
+
+
+def _run_cli(monkeypatch, tmp_path, extra_args):
+    captured = {}
+
+    def fake_run_pipeline(inputs, shapes, base_iri, *, ontologies=None, **kwargs):
+        captured["ontologies"] = list(ontologies or [])
+        return {"combined_ttl": "", "violation_stats": {}, "shacl_conforms": True}
+
+    monkeypatch.setattr(rb, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(rb, "compute_metrics", lambda *a, **k: {"precision": 0, "recall": 0, "f1": 0})
+
+    argv = [
+        "run_benchmark.py",
+        "--pairs",
+        "req:gold:shapes",
+        "--settings",
+        '[{"name": "t"}]',
+        "--repeats",
+        "1",
+        "--output-dir",
+        str(tmp_path),
+    ] + extra_args
+    monkeypatch.setattr(sys, "argv", argv)
+    rb.main()
+    return captured["ontologies"]
+
+
+def test_cli_accepts_ontologies(monkeypatch, tmp_path):
+    a = tmp_path / "a.ttl"
+    a.write_text("")
+    b = tmp_path / "b.ttl"
+    b.write_text("")
+
+    result = _run_cli(monkeypatch, tmp_path, ["--ontologies", str(a), str(b)])
+    assert result == [str(a), str(b)]
+
+
+def test_cli_accepts_ontology_dir(monkeypatch, tmp_path):
+    d = tmp_path / "dir"
+    d.mkdir()
+    x = d / "x.ttl"
+    x.write_text("")
+    y = d / "y.ttl"
+    y.write_text("")
+    (d / "ignore.txt").write_text("no")
+
+    result = _run_cli(monkeypatch, tmp_path, ["--ontology-dir", str(d)])
+    assert set(result) == {str(x), str(y)}


### PR DESCRIPTION
## Summary
- allow `evaluation/run_benchmark.py` to accept `--ontology-dir` and forward resolved `.ttl` files to each run
- document specifying domain ontologies with `--ontologies` or `--ontology-dir`
- test CLI to ensure ontology paths reach `run_pipeline`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa117a6e2c8330a1ef02b54b808a25