### PR TITLE
Deduplicate sentences in preprocess_text

### DIFF
--- a/ontology_guided/data_loader.py
+++ b/ontology_guided/data_loader.py
@@ -71,4 +71,5 @@ class DataLoader:
                 has_verb = any(token.pos_ in {"VERB", "AUX"} for token in sent)
                 if has_keyword or has_verb:
                     sentences.append(sent_text)
-        return sentences
+        # Remove duplicates while preserving order
+        return list(dict.fromkeys(sentences))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -64,3 +64,18 @@ def test_preprocess_filters_noisy_inputs():
         "Users must change password.",
     ]
 
+
+def test_preprocess_removes_duplicate_sentences():
+    loader = DataLoader()
+    text = (
+        "The system shall reboot.\n"
+        "Users must change password.\n"
+        "The system shall reboot.\n"
+        "Users must change password."
+    )
+    sentences = loader.preprocess_text(text)
+    assert sentences == [
+        "The system shall reboot.",
+        "Users must change password.",
+    ]
+


### PR DESCRIPTION
## Summary
- remove duplicate sentences in `DataLoader.preprocess_text` while preserving order
- add regression test ensuring repeated lines produce unique sentences

## Testing
- `pytest tests/test_loader.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1871b3a88330ba2fd015ce825f29