### PR TITLE
Add ATM example pairs and wire examples through benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ python3 evaluation/compare_metrics.py evaluation/atm_requirements.txt evaluation
 Για την αναπαραγωγή πινάκων αξιολόγησης σε διαφορετικές ρυθμίσεις, υπάρχει το script:
 
 ```bash
-python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" --repeats 1
+python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" --examples evaluation/atm_examples.json --repeats 1
 ```
 
 Το script εκτελεί το pipeline με όλους τους συνδυασμούς των σημαιών `use_terms` και `validate`,
@@ -188,6 +188,7 @@ python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:eva
 ```bash
 python3 evaluation/run_benchmark.py \
     --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" \
+    --examples evaluation/atm_examples.json \
     --ontology-dir ontologies \
     --repeats 1
 ```
@@ -197,6 +198,7 @@ python3 evaluation/run_benchmark.py \
 ```bash
 python -m evaluation.run_benchmark \
     --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" \
+    --examples evaluation/atm_examples.json \
     --settings '[{"name":"table1","use_terms":true,"validate":true,"ontologies":["ontologies/rbo.ttl","ontologies/lexical.ttl"]}]'
 ```
 

--- a/evaluation/atm_examples.json
+++ b/evaluation/atm_examples.json
@@ -1,0 +1,10 @@
+[
+  {
+    "user": "The ATM dispenses cash.",
+    "assistant": "@prefix atm: <http://lod.csd.auth.gr/atm/atm.ttl#> .\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\natm:ATM a owl:Class .\natm:Cash a owl:Class .\natm:dispenses a owl:ObjectProperty .\natm:ATM atm:dispenses atm:Cash ."
+  },
+  {
+    "user": "A cash card has a serial number.",
+    "assistant": "@prefix atm: <http://lod.csd.auth.gr/atm/atm.ttl#> .\n@prefix owl: <http://www.w3.org/2002/07/owl#> .\natm:CashCard a owl:Class .\natm:SerialNumber a owl:Class .\natm:hasSerialNumber a owl:ObjectProperty .\natm:CashCard atm:hasSerialNumber atm:SerialNumber ."
+  }
+]

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -9,6 +9,7 @@ Example
 -------
 python -m evaluation.run_benchmark \
     --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" \
+    --examples evaluation/atm_examples.json \
     --base-iri http://lod.csd.auth.gr/atm/atm.ttl# \
     --repeats 1
 
@@ -208,6 +209,11 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         help="List of requirements:gold[:shapes] triples",
     )
     parser.add_argument(
+        "--examples",
+        default=None,
+        help="Path to JSON file with few-shot examples",
+    )
+    parser.add_argument(
         "--settings",
         type=str,
         default=None,
@@ -266,8 +272,14 @@ def main() -> None:  # pragma: no cover - CLI wrapper
             "ontologies/lexical.ttl",
             "ontologies/lexical_atm.ttl",
         ]
+    examples = None
+    if args.examples:
+        with open(args.examples, "r", encoding="utf-8") as f:
+            examples = json.load(f)
     for setting in settings_list:
         setting.setdefault("ontologies", ontology_list)
+        if examples is not None:
+            setting.setdefault("examples", examples)
 
     run_evaluations(
         pairs,

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -127,7 +127,7 @@ def run_pipeline(
                     batch, PROMPT_TEMPLATE, available_terms=avail_terms
                 )
             else:
-                owl_batch = llm.generate_owl_sync(
+                owl_batch = llm.generate_owl(
                     batch, PROMPT_TEMPLATE, available_terms=avail_terms
                 )
             for sent, snippet in zip(batch, owl_batch):
@@ -156,7 +156,7 @@ def run_pipeline(
                 batch, PROMPT_TEMPLATE, available_terms=avail_terms
             )
         else:
-            owl_batch = llm.generate_owl_sync(
+            owl_batch = llm.generate_owl(
                 batch, PROMPT_TEMPLATE, available_terms=avail_terms
             )
         for sent, snippet in zip(batch, owl_batch):


### PR DESCRIPTION
## Summary
- add `evaluation/atm_examples.json` containing ATM requirement→turtle pairs
- allow `evaluation/run_benchmark.py` to pass `--examples` and document usage in README
- load `examples` from file in `LLMInterface` and forward them when calling the OpenAI API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa1fa21b788330a5c47f429e92bf27