### PR TITLE
Use typing.Union for examples parameter

### DIFF
--- a/ontology_guided/llm_interface.py
+++ b/ontology_guided/llm_interface.py
@@ -1,6 +1,6 @@
 import openai
 import httpx
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Union
 import re
 import time
 import asyncio
@@ -31,7 +31,7 @@ class LLMInterface:
         model: str = "gpt-4",
         cache_dir: Optional[str] = None,
         temperature: float = 0.0,
-        examples: Optional[List[Dict[str, str]] | str | Path] = None,
+        examples: Optional[Union[List[Dict[str, str]], str, Path]] = None,
     ):
         openai.api_key = api_key
         self.model = model


### PR DESCRIPTION
## Summary
- use typing.Union for `examples` parameter in `LLMInterface.__init__`

## Testing
- `python -m py_compile ontology_guided/llm_interface.py`
- `python3.9 -m py_compile ontology_guided/llm_interface.py` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa240944e08330a4f84738f5d7c27f