### PR TITLE
Add strict term filtering option

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -46,6 +46,7 @@ def run_pipeline(
     use_terms: bool = True,
     validate: bool = True,
     use_async: bool = False,
+    strict_terms: bool = False,
 ):
     """Execute the ontology drafting pipeline.
 
@@ -59,7 +60,8 @@ def run_pipeline(
     the maximum number of repair iterations, while ``reason`` and ``inference``
     control reasoning behaviour within the repair loop. ``use_terms`` controls
     whether ontology terms are supplied to the language model. ``validate``
-    toggles SHACL validation and the subsequent repair loop.
+    toggles SHACL validation and the subsequent repair loop. ``strict_terms``
+    discards triples that contain unknown ontology terms.
     """
     load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
@@ -140,6 +142,7 @@ def run_pipeline(
                         logger=logger,
                         requirement=sent,
                         snippet_index=snippet_counter,
+                        strict_terms=strict_terms,
                     )
                     builder.add_provenance(sent, triples)
                     if use_terms:
@@ -169,6 +172,7 @@ def run_pipeline(
                     logger=logger,
                     requirement=sent,
                     snippet_index=snippet_counter,
+                    strict_terms=strict_terms,
                 )
                 builder.add_provenance(sent, triples)
                 if use_terms:
@@ -291,6 +295,11 @@ def main():
         help="Skip SHACL validation and the repair loop",
     )
     parser.add_argument(
+        "--strict-terms",
+        action="store_true",
+        help="Απόρριψη triples με άγνωστους όρους",
+    )
+    parser.add_argument(
         "--async",
         dest="use_async",
         action="store_true",
@@ -322,6 +331,7 @@ def main():
             use_terms=not args.no_terms,
             validate=not args.no_shacl,
             use_async=args.use_async,
+            strict_terms=args.strict_terms,
         )
     except RuntimeError as exc:
         logging.getLogger(__name__).error("Pipeline aborted: %s", exc)


### PR DESCRIPTION
## Summary
- allow pipeline to discard triples with unknown ontology terms
- expose strict term filtering via CLI flag

## Testing
- `pytest`
- `python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" --examples evaluation/atm_examples.json --base-iri http://lod.csd.auth.gr/atm/atm.ttl# --settings '[{"name":"no_terms","use_terms":false,"validate":true,"reason":true,"strict_terms":true},{"name":"no_reasoner","use_terms":true,"validate":true,"reason":false,"strict_terms":true},{"name":"no_shacl","use_terms":true,"validate":false,"reason":true,"strict_terms":true},{"name":"full","use_terms":true,"validate":true,"reason":true,"repair":true,"strict_terms":true}]'` (fails: Set OPENAI_API_KEY in .env)


------
https://chatgpt.com/codex/tasks/task_e_68aa261b320c8330b2a6d16fc52c890a