### PR TITLE
Allow base IRI and prefix in LLM prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ python3 scripts/generate_dfd.py
    - `--no-terms`: δεν παρέχονται διαθέσιμοι όροι της οντολογίας στο LLM (προεπιλογή: παρέχονται).
    - `--no-shacl`: απενεργοποίηση του ελέγχου SHACL και του βρόχου διόρθωσης (προεπιλογή: ενεργοποιημένα).
 
+   Η προτροπή προς το LLM πλέον περιλαμβάνει οδηγίες για το base IRI και το prefix, ώστε τα παραγόμενα IRIs να είναι συνεπή. Παράδειγμα:
+
+   ```python
+   from scripts.main import PROMPT_TEMPLATE
+
+   print(
+       PROMPT_TEMPLATE.format(
+           sentence="The ATM authenticates cards.",
+           base="http://example.com/atm#",
+           prefix="atm",
+       )
+   )
+   ```
+
+   Παράγει απόσπασμα τύπου:
+
+   ```turtle
+   @prefix atm: <http://example.com/atm#> .
+   atm:Authentication a owl:Class .
+   ```
+
    Παράδειγμα με προσαρμοσμένες επιλογές:
    ```bash
    python3 scripts/main.py --inputs demo.txt --shapes shapes.ttl --ontology-dir ontologies --rbo --lexical --base-iri http://example.com/atm#

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -17,7 +17,8 @@ from ontology_guided.validator import SHACLValidator
 from ontology_guided.repair_loop import RepairLoop
 
 PROMPT_TEMPLATE = (
-    "Convert the following requirement into OWL axioms in Turtle syntax:\n\n"
+    "Convert the following requirement into OWL axioms in Turtle syntax. "
+    "Use base IRI {base} and prefix {prefix}.\n\n"
     "Requirement: {sentence}\n\nOWL:"
 )
 
@@ -126,11 +127,19 @@ def run_pipeline(
         if len(batch) >= BATCH_SIZE:
             if use_async:
                 owl_batch = llm.async_generate_owl(
-                    batch, PROMPT_TEMPLATE, available_terms=avail_terms
+                    batch,
+                    PROMPT_TEMPLATE,
+                    base=base_iri,
+                    prefix=builder.prefix,
+                    available_terms=avail_terms,
                 )
             else:
                 owl_batch = llm.generate_owl(
-                    batch, PROMPT_TEMPLATE, available_terms=avail_terms
+                    batch,
+                    PROMPT_TEMPLATE,
+                    base=base_iri,
+                    prefix=builder.prefix,
+                    available_terms=avail_terms,
                 )
             for sent, snippet in zip(batch, owl_batch):
                 if len(snippets_preview) < PREVIEW_LIMIT:
@@ -156,11 +165,19 @@ def run_pipeline(
     if batch:
         if use_async:
             owl_batch = llm.async_generate_owl(
-                batch, PROMPT_TEMPLATE, available_terms=avail_terms
+                batch,
+                PROMPT_TEMPLATE,
+                base=base_iri,
+                prefix=builder.prefix,
+                available_terms=avail_terms,
             )
         else:
             owl_batch = llm.generate_owl(
-                batch, PROMPT_TEMPLATE, available_terms=avail_terms
+                batch,
+                PROMPT_TEMPLATE,
+                base=base_iri,
+                prefix=builder.prefix,
+                available_terms=avail_terms,
             )
         for sent, snippet in zip(batch, owl_batch):
             if len(snippets_preview) < PREVIEW_LIMIT:

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -10,7 +10,14 @@ def test_compare_metrics(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         snippet = (
             "<http://lod.csd.auth.gr/atm/atm.ttl> "
             "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> "

--- a/tests/test_healthcare_switch.py
+++ b/tests/test_healthcare_switch.py
@@ -8,7 +8,14 @@ def test_pipeline_switches_to_healthcare(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return [
             "@prefix hc: <http://example.com/healthcare#> .\n"
             "hc:obs1 a hc:Observation ;\n"

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -18,7 +18,14 @@ atm:alice atm:knows atm:bob .""",
     shapes_path = tmp_path / "shapes.ttl"
     shapes_path.write_text("", encoding="utf-8")
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return [
             "<http://example.com/atm#alice> <http://example.com/atm#friend> <http://example.com/atm#bob> ."
         ]

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -9,7 +9,14 @@ def test_run_pipeline_custom_settings(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
 
     monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
@@ -37,7 +44,14 @@ def test_run_pipeline_collects_failed_snippets(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return ["invalid turtle"]
 
     monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
@@ -67,7 +81,14 @@ def test_run_pipeline_ontology_dir(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
 
     monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
@@ -83,6 +104,7 @@ def test_run_pipeline_ontology_dir(monkeypatch, tmp_path):
         def __init__(self, base_iri, ontology_files=None):
             captured["files"] = list(ontology_files or [])
             self.triple_provenance = {}
+            self.prefix = "atm"
 
         def get_available_terms(self):
             return {"classes": [], "properties": [], "domain_range_hints": {}, "synonyms": {}}
@@ -119,7 +141,14 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
 
     monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
@@ -187,7 +216,14 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
 
     monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)
@@ -242,7 +278,14 @@ def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.chdir(tmp_path)
 
-    def fake_generate_owl(self, sentences, prompt_template, available_terms=None):
+    def fake_generate_owl(
+        self,
+        sentences,
+        prompt_template,
+        available_terms=None,
+        base=None,
+        prefix=None,
+    ):
         return ["@prefix atm: <http://example.com/atm#> .\natm:dummy a atm:Unused ."]
 
     monkeypatch.setattr(LLMInterface, "generate_owl", fake_generate_owl)


### PR DESCRIPTION
## Summary
- allow PROMPT_TEMPLATE to request specific base IRI and prefix
- pass base and prefix through `run_pipeline` to `LLMInterface`
- extend `LLMInterface` to include base/prefix in prompts and cache keys
- document base/prefix usage with example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa28b1ca788330abf625b81cbf7c20