### PR TITLE
Add keyword filtering options

### DIFF
--- a/evaluation/compare_metrics.py
+++ b/evaluation/compare_metrics.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 from rdflib import Graph
+from typing import Iterable
 
 import os, sys
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -15,6 +16,7 @@ def compare_metrics(
     gold_path: str,
     shapes_path: str = "shapes.ttl",
     base_iri: str = "http://lod.csd.auth.gr/atm/atm.ttl#",
+    keywords: Iterable[str] | None = None,
 ) -> dict:
     """Run the pipeline on requirements and compare against a gold TTL file.
 
@@ -40,6 +42,7 @@ def compare_metrics(
         base_iri,
         spacy_model="en",
         inference="none",
+        keywords=keywords,
     )
     predicted_ttl = result["combined_ttl"]
 
@@ -81,9 +84,21 @@ def main():
         default="http://lod.csd.auth.gr/atm/atm.ttl#",
         help="Base IRI for the generated ontology",
     )
+    parser.add_argument(
+        "--keywords",
+        default=None,
+        help="Comma-separated keywords for sentence filtering",
+    )
     args = parser.parse_args()
 
-    metrics = compare_metrics(args.requirements, args.gold, args.shapes, args.base_iri)
+    keywords = (
+        [k.strip() for k in args.keywords.split(",") if k.strip()]
+        if args.keywords
+        else None
+    )
+    metrics = compare_metrics(
+        args.requirements, args.gold, args.shapes, args.base_iri, keywords=keywords
+    )
     print(f"Precision: {metrics['precision']:.3f}")
     print(f"Recall: {metrics['recall']:.3f}")
     print(f"F1: {metrics['f1']:.3f}")

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -98,11 +98,17 @@ def evaluate_once(
     base_iri: str,
     ontologies: Sequence[str] | None = None,
     normalize_base: bool = False,
+    keywords: Iterable[str] | None = None,
     **settings: Any,
 ) -> Tuple[Dict[str, float], Dict[str, Any], Any]:
     """Run the pipeline once and compute evaluation metrics."""
     result = run_pipeline(
-        [requirements], shapes, base_iri, ontologies=ontologies, **settings
+        [requirements],
+        shapes,
+        base_iri,
+        ontologies=ontologies,
+        keywords=keywords,
+        **settings,
     )
     metrics = compute_metrics(
         result["combined_ttl"], gold, normalize_base=normalize_base
@@ -138,6 +144,7 @@ def run_evaluations(
     base_iri: str,
     output_dir: Path,
     normalize_base: bool = False,
+    keywords: Iterable[str] | None = None,
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -158,6 +165,7 @@ def run_evaluations(
                     shapes,
                     base_iri,
                     normalize_base=normalize_base,
+                    keywords=keywords,
                     **pipeline_opts,
                 )
                 metrics_list.append(metrics)
@@ -248,6 +256,11 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         action="store_true",
         help="Normalize base IRIs before comparing graphs",
     )
+    parser.add_argument(
+        "--keywords",
+        default=None,
+        help="Comma-separated keywords for sentence filtering",
+    )
     args = parser.parse_args()
 
     pairs = [parse_pair(p) for p in args.pairs]
@@ -281,6 +294,11 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         if examples is not None:
             setting.setdefault("examples", examples)
 
+    keywords = (
+        [k.strip() for k in args.keywords.split(",") if k.strip()]
+        if args.keywords
+        else None
+    )
     run_evaluations(
         pairs,
         settings_list,
@@ -288,6 +306,7 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         args.base_iri,
         Path(args.output_dir),
         normalize_base=args.normalize_base,
+        keywords=keywords,
     )
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -79,3 +79,17 @@ def test_preprocess_removes_duplicate_sentences():
         "Users must change password.",
     ]
 
+
+def test_preprocess_custom_keywords():
+    loader = DataLoader()
+    text = "Requirement: optional item."
+    sentences = loader.preprocess_text(text, keywords=["requirement"])
+    assert sentences == ["Requirement: optional item."]
+
+
+def test_preprocess_no_keywords_argument():
+    loader = DataLoader()
+    text = "Logging is enabled."
+    sentences = loader.preprocess_text(text, keywords=None)
+    assert sentences == ["Logging is enabled."]
+


### PR DESCRIPTION
## Summary
- Allow `DataLoader.preprocess_text` to accept an optional keyword list and skip filtering when none are provided.
- Add `--keywords` flag to the main CLI and evaluation scripts, forwarding custom keyword sets to sentence preprocessing.
- Extend tests for loader to cover custom keyword usage and no-keyword behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a3b168c8330abf4c963429e6f4a