### PR TITLE
Ensure compatibility with Python 3.9 union types

### DIFF
--- a/evaluation/compare_metrics.py
+++ b/evaluation/compare_metrics.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 from rdflib import Graph
-from typing import Iterable
+from typing import Iterable, Optional, Union
 
 import os, sys
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -16,7 +16,7 @@ def compare_metrics(
     gold_path: str,
     shapes_path: str = "shapes.ttl",
     base_iri: str = "http://lod.csd.auth.gr/atm/atm.ttl#",
-    keywords: Iterable[str] | None = None,
+    keywords: Optional[Union[Iterable[str], None]] = None,
 ) -> dict:
     """Run the pipeline on requirements and compare against a gold TTL file.
 

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -23,7 +23,7 @@ import argparse
 import json
 from pathlib import Path
 from statistics import mean
-from typing import Any, Dict, Iterable, List, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Sequence, Tuple, Optional, Union
 
 from rdflib import Graph
 from rdflib.term import URIRef
@@ -96,9 +96,9 @@ def evaluate_once(
     gold: str,
     shapes: str,
     base_iri: str,
-    ontologies: Sequence[str] | None = None,
+    ontologies: Optional[Union[Sequence[str], None]] = None,
     normalize_base: bool = False,
-    keywords: Iterable[str] | None = None,
+    keywords: Optional[Union[Iterable[str], None]] = None,
     **settings: Any,
 ) -> Tuple[Dict[str, float], Dict[str, Any], Any]:
     """Run the pipeline once and compute evaluation metrics."""
@@ -144,7 +144,7 @@ def run_evaluations(
     base_iri: str,
     output_dir: Path,
     normalize_base: bool = False,
-    keywords: Iterable[str] | None = None,
+    keywords: Optional[Union[Iterable[str], None]] = None,
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/ontology_guided/data_loader.py
+++ b/ontology_guided/data_loader.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import re
-from typing import Iterable, Iterator, List
+from typing import Iterable, Iterator, List, Optional, Union
 import spacy
 from docx import Document  # pip install python-docx
 
@@ -55,7 +55,7 @@ class DataLoader:
         text: str,
         batch_size: int = 100,
         n_process: int = 1,
-        keywords: Iterable[str] | None = ("shall", "must", "should"),
+        keywords: Optional[Union[Iterable[str], None]] = ("shall", "must", "should"),
     ) -> List[str]:
         """Καθαρίζει το κείμενο και το επεξεργάζεται τμηματικά με το spaCy.
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 import sys
 import logging
 import json
-from typing import Iterable
+from typing import Iterable, Optional, Union
 
 # Ensure the project root is on the Python path when executed directly
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -49,7 +49,7 @@ def run_pipeline(
     validate: bool = True,
     use_async: bool = False,
     strict_terms: bool = False,
-    keywords: Iterable[str] | None = None,
+    keywords: Optional[Union[Iterable[str], None]] = None,
 ):
     """Execute the ontology drafting pipeline.
 


### PR DESCRIPTION
## Summary
- Replace PEP 604 `|` unions with `Optional`/`Union` annotations
- Import `Union` in modules that previously used `|` type syntax
- Keep existing functionality while ensuring Python 3.9 compatibility

## Testing
- `python -m pytest`
- `python3.9 -m pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2dbcc7a0833090a6ea28811970fe