### PR TITLE
Update evaluation scripts for JSONL requirement files

### DIFF
--- a/evaluation/compare_metrics.py
+++ b/evaluation/compare_metrics.py
@@ -1,3 +1,11 @@
+"""CLI to evaluate ontology generation against a gold standard.
+
+Example
+-------
+python -m evaluation.compare_metrics \
+    evaluation/atm_requirements.jsonl evaluation/atm_gold.ttl
+"""
+
 import argparse
 from pathlib import Path
 from rdflib import Graph
@@ -23,7 +31,7 @@ def compare_metrics(
     Parameters
     ----------
     requirements_path: str
-        Path to requirements text file.
+        Path to requirements JSONL file.
     gold_path: str
         Path to gold standard TTL file containing expected triples.
     shapes_path: str
@@ -76,7 +84,7 @@ def compare_metrics(
 
 def main():
     parser = argparse.ArgumentParser(description="Compare generated OWL with gold standard")
-    parser.add_argument("requirements", help="Path to requirements text file")
+    parser.add_argument("requirements", help="Path to requirements JSONL file")
     parser.add_argument("gold", help="Path to gold standard TTL file")
     parser.add_argument("--shapes", default="shapes.ttl", help="Path to SHACL shapes file")
     parser.add_argument(

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -8,7 +8,7 @@ reproduce the evaluation tables (Tables 1–4) of the associated paper.
 Example
 -------
 python -m evaluation.run_benchmark \
-    --pairs "evaluation/atm_requirements.txt:evaluation/atm_gold.ttl" \
+    --pairs "evaluation/atm_requirements.jsonl:evaluation/atm_gold.ttl" \
     --examples evaluation/atm_examples.json \
     --base-iri http://lod.csd.auth.gr/atm/atm.ttl# \
     --repeats 1
@@ -213,7 +213,7 @@ def main() -> None:  # pragma: no cover - CLI wrapper
     parser.add_argument(
         "--pairs",
         nargs="+",
-        default=["evaluation/atm_requirements.txt:evaluation/atm_gold.ttl"],
+        default=["evaluation/atm_requirements.jsonl:evaluation/atm_gold.ttl"],
         help="List of requirements:gold[:shapes] triples",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- adjust run_benchmark examples and default paths to point to `atm_requirements.jsonl`
- clarify compare_metrics docs/CLI to accept JSONL requirement files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b178dd1f808330acc9bafde07261af