### PR TITLE
Add JSONL requirement loading

### DIFF
--- a/ontology_guided/data_loader.py
+++ b/ontology_guided/data_loader.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import re
+import json
 from typing import Iterable, Iterator, List, Optional, Union
 import spacy
 from docx import Document  # pip install python-docx
@@ -37,6 +38,14 @@ class DataLoader:
         for para in doc.paragraphs:
             yield para.text
 
+    def load_jsonl_file(self, file_path: str) -> Iterator[str]:
+        """Yield the ``text`` field from each JSONL line."""
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    data = json.loads(line)
+                    yield data["text"]
+
     def load_requirements(self, input_paths: List[str]) -> Iterable[str]:
         for path in input_paths:
             if not os.path.exists(path):
@@ -47,6 +56,8 @@ class DataLoader:
                 yield from self.load_text_file(path)
             elif ext == ".docx":
                 yield from self.load_docx_file(path)
+            elif ext == ".jsonl":
+                yield from self.load_jsonl_file(path)
             else:
                 raise ValueError(f"Unsupported file extension: {ext}")
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pytest
 
@@ -33,6 +34,30 @@ def test_docx_loading_and_preprocessing(tmp_path):
     for line in lines:
         sentences.extend(loader.preprocess_text(line))
     assert sentences == []
+
+
+def test_jsonl_loading_and_preprocessing(tmp_path):
+    data = [
+        {"text": "* The system shall reboot."},
+        {"text": "1. Users must change password."},
+    ]
+    file_path = tmp_path / "reqs.jsonl"
+    with open(file_path, "w", encoding="utf-8") as f:
+        for obj in data:
+            json.dump(obj, f)
+            f.write("\n")
+
+    loader = DataLoader()
+    lines = list(loader.load_requirements([str(file_path)]))
+    assert lines == [obj["text"] for obj in data]
+
+    sentences = []
+    for line in lines:
+        sentences.extend(loader.preprocess_text(line))
+    assert sentences == [
+        "The system shall reboot.",
+        "Users must change password.",
+    ]
 
 
 def test_load_requirements_warns_and_raises(tmp_path, caplog):


### PR DESCRIPTION
## Summary
- support reading JSONL files by returning each line's `text`
- dispatch `.jsonl` extension in `load_requirements`
- test JSONL loading and preprocessing

## Testing
- `pytest tests/test_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17b22714083308bd2d270cab087fa