### PR TITLE
feat: add semantic axiom matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ python3 scripts/main.py \
 ```bash
 python3 evaluation/compare_metrics.py evaluation/atm_requirements.jsonl evaluation/atm_gold.ttl
 ```
+Μπορείτε να επιλέξετε στρατηγική αντιστοίχισης αξιωμάτων με την επιλογή `--match-mode` (`syntactic` ή `semantic`), με προεπιλογή το `syntactic`.
 
 Το script υπολογίζει **precision** και **recall** χρησιμοποιώντας τις απαιτήσεις από το `atm_requirements.jsonl` (μορφή JSON Lines) και αποθηκεύει τις μετρικές στο `results/metrics.txt`.
 

--- a/evaluation/axiom_metrics.py
+++ b/evaluation/axiom_metrics.py
@@ -1,15 +1,31 @@
-"""Utility to compute axiom-level precision, recall and F1 between RDF graphs."""
+"""Utility to compute axiom-level precision, recall and F1 between RDF graphs.
+
+Two matching strategies are provided:
+
+* ``syntactic`` (default): exact IRI comparison after normalising any
+  ``rdfs:label`` values to IRIs.
+* ``semantic``: expands both graphs using OWL RL reasoning before comparison
+  to account for entailed axioms.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Dict, Set, Tuple
+import re
+from typing import Dict, Iterable, Set, Tuple, Union
 
 from rdflib import Graph, OWL
 from rdflib.namespace import RDF, RDFS
+from rdflib.term import Node, URIRef
+
+try:  # OWL RL reasoning for semantic matching
+    from owlrl import DeductiveClosure, OWLRL_Semantics
+except Exception:  # pragma: no cover - owlrl is optional at runtime
+    DeductiveClosure = None
+    OWLRL_Semantics = None
 
 # Type alias for sets of axioms represented as hashable tuples or nodes
-AxiomSet = Set
+NormalizedAxiom = Union[str, Tuple[str, str]]
+AxiomSet = Set[NormalizedAxiom]
 
 # Mapping axiom type names to callables extracting corresponding sets from a graph
 AXIOM_EXTRACTORS = {
@@ -20,6 +36,51 @@ AXIOM_EXTRACTORS = {
     "Domain": lambda g: set(g.subject_objects(RDFS.domain)),
     "Range": lambda g: set(g.subject_objects(RDFS.range)),
 }
+
+
+def _label_to_iri(label: str) -> str:
+    """Normalise a label into an IRI fragment.
+
+    This mirrors the behaviour of many ontology generation pipelines that
+    convert labels to IRIs by lowercasing and replacing non-alphanumeric
+    characters with ``_``.
+    """
+
+    return re.sub(r"[^a-zA-Z0-9]+", "_", label.strip()).strip("_").lower()
+
+
+def _normalise_term(term: Node, graph: Graph) -> str:
+    """Normalise a node to a comparable string value."""
+
+    if isinstance(term, URIRef):
+        return str(term)
+    label = next(graph.objects(term, RDFS.label), None)
+    if label:
+        return _label_to_iri(str(label))
+    return str(term)
+
+
+def _normalise_axioms(axioms: Iterable, graph: Graph) -> AxiomSet:
+    """Return a set of normalised axioms for comparison."""
+
+    normalised: AxiomSet = set()
+    for ax in axioms:
+        if isinstance(ax, tuple):
+            normalised.add(tuple(_normalise_term(t, graph) for t in ax))
+        else:
+            normalised.add(_normalise_term(ax, graph))
+    return normalised
+
+
+def _semantic_closure(graph: Graph) -> Graph:
+    """Expand ``graph`` using OWL RL reasoning if available."""
+
+    if DeductiveClosure is None:  # pragma: no cover - optional dependency
+        return graph
+    closure = Graph()
+    closure += graph
+    DeductiveClosure(OWLRL_Semantics).expand(closure)
+    return closure
 
 
 def _metrics(pred: AxiomSet, gold: AxiomSet) -> Dict[str, float]:
@@ -38,16 +99,36 @@ def _metrics(pred: AxiomSet, gold: AxiomSet) -> Dict[str, float]:
 
 
 def evaluate_axioms(
-    pred_graph: Graph, gold_graph: Graph, micro: bool = False
+    pred_graph: Graph,
+    gold_graph: Graph,
+    micro: bool = False,
+    match_mode: str = "syntactic",
 ) -> Dict[str, Dict[str, float]]:
-    """Compute axiom-level metrics grouped by axiom type."""
+    """Compute axiom-level metrics grouped by axiom type.
+
+    Parameters
+    ----------
+    pred_graph, gold_graph:
+        Graphs to compare.
+    micro:
+        Whether to compute micro-averaged metrics in addition to macro.
+    match_mode:
+        ``"syntactic"`` (default) performs exact IRI comparison after label
+        normalisation. ``"semantic"`` expands both graphs with an OWL RL
+        reasoner before comparison to account for entailed axioms.
+    """
+
+    if match_mode == "semantic":
+        pred_graph = _semantic_closure(pred_graph)
+        gold_graph = _semantic_closure(gold_graph)
+
     per_type: Dict[str, Dict[str, float]] = {}
     macro_f1_total = 0.0
     total_tp = total_pred = total_gold = 0
 
     for axiom_type, extractor in AXIOM_EXTRACTORS.items():
-        pred_set = extractor(pred_graph)
-        gold_set = extractor(gold_graph)
+        pred_set = _normalise_axioms(extractor(pred_graph), pred_graph)
+        gold_set = _normalise_axioms(extractor(gold_graph), gold_graph)
         m = _metrics(pred_set, gold_set)
         per_type[axiom_type] = {
             "precision": m["precision"],

--- a/evaluation/compare_metrics.py
+++ b/evaluation/compare_metrics.py
@@ -29,6 +29,7 @@ def compare_metrics(
     keywords: Optional[Union[Iterable[str], None]] = None,
     micro: bool = False,
     output_path: str = "results/axiom_metrics.json",
+    match_mode: str = "syntactic",
 ) -> dict:
     """Run the pipeline on requirements and compare against a gold TTL file.
 
@@ -76,7 +77,9 @@ def compare_metrics(
         else 0.0
     )
 
-    axiom_metrics = evaluate_axioms(pred_graph, gold_graph, micro=micro)
+    axiom_metrics = evaluate_axioms(
+        pred_graph, gold_graph, micro=micro, match_mode=match_mode
+    )
 
     # Include triple-level metrics for backward compatibility
     axiom_metrics.update(
@@ -113,6 +116,12 @@ def main():
         help="Compute micro-averaged precision/recall/F1",
     )
     parser.add_argument(
+        "--match-mode",
+        choices=["syntactic", "semantic"],
+        default="syntactic",
+        help="Axiom matching mode (default: syntactic)",
+    )
+    parser.add_argument(
         "--out",
         default="results/axiom_metrics.json",
         help="Path to save computed metrics",
@@ -132,6 +141,7 @@ def main():
         keywords=keywords,
         micro=args.micro,
         output_path=args.out,
+        match_mode=args.match_mode,
     )
 
     for axiom, vals in metrics.get("per_type", {}).items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ spacy>=3.0
 python-docx
 openai>=1.0.0
 rdflib
+owlrl
 owlready2
 python-dotenv
 pyshacl


### PR DESCRIPTION
## Summary
- support configurable syntactic or semantic axiom comparison
- expose `--match-mode` CLI option in evaluation tool
- document matching modes and include owlrl dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b17f6abdc483309a4ccf07f49d6ad7