### PR TITLE
Add equivalent class evaluation options

### DIFF
--- a/evaluation/compare_metrics.py
+++ b/evaluation/compare_metrics.py
@@ -30,6 +30,7 @@ def compare_metrics(
     micro: bool = False,
     output_path: str = "results/axiom_metrics.json",
     match_mode: str = "syntactic",
+    equiv_as_subclass: bool = False,
 ) -> dict:
     """Run the pipeline on requirements and compare against a gold TTL file.
 
@@ -43,6 +44,10 @@ def compare_metrics(
         Path to SHACL shapes file.
     base_iri: str
         Base IRI for the generated ontology.
+    equiv_as_subclass: bool
+        If ``True`` treat ``owl:equivalentClass`` axioms as two ``SubClassOf``
+        axioms. Otherwise they are evaluated separately under an
+        ``EquivalentClasses`` bucket.
 
     Returns
     -------
@@ -78,7 +83,11 @@ def compare_metrics(
     )
 
     axiom_metrics = evaluate_axioms(
-        pred_graph, gold_graph, micro=micro, match_mode=match_mode
+        pred_graph,
+        gold_graph,
+        micro=micro,
+        match_mode=match_mode,
+        equiv_as_subclass=equiv_as_subclass,
     )
 
     # Include triple-level metrics for backward compatibility
@@ -122,6 +131,11 @@ def main():
         help="Axiom matching mode (default: syntactic)",
     )
     parser.add_argument(
+        "--equiv-as-subclass",
+        action="store_true",
+        help="Score owl:equivalentClass axioms as two SubClassOf axioms",
+    )
+    parser.add_argument(
         "--out",
         default="results/axiom_metrics.json",
         help="Path to save computed metrics",
@@ -142,6 +156,7 @@ def main():
         micro=args.micro,
         output_path=args.out,
         match_mode=args.match_mode,
+        equiv_as_subclass=args.equiv_as_subclass,
     )
 
     for axiom, vals in metrics.get("per_type", {}).items():

--- a/tests/test_axiom_metrics.py
+++ b/tests/test_axiom_metrics.py
@@ -1,0 +1,39 @@
+import pytest
+from rdflib import Graph
+
+from evaluation.axiom_metrics import evaluate_axioms
+
+
+def _graph_with_equiv() -> Graph:
+    g = Graph()
+    g.parse(
+        data=(
+            "@prefix : <http://example.com/> .\n"
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n"
+            ":A owl:equivalentClass :B ."
+        ),
+        format="turtle",
+    )
+    return g
+
+
+def test_equivalent_classes_bucket():
+    g_pred = _graph_with_equiv()
+    g_gold = _graph_with_equiv()
+    metrics = evaluate_axioms(g_pred, g_gold)
+    eq = metrics["per_type"]["EquivalentClasses"]
+    assert eq["precision"] == pytest.approx(1.0)
+    assert eq["recall"] == pytest.approx(1.0)
+    # SubClassOf should have no entries
+    assert metrics["per_type"]["SubClassOf"]["precision"] == pytest.approx(0.0)
+
+
+def test_equivalent_classes_as_subclass():
+    g_pred = _graph_with_equiv()
+    g_gold = _graph_with_equiv()
+    metrics = evaluate_axioms(g_pred, g_gold, equiv_as_subclass=True)
+    assert "EquivalentClasses" not in metrics["per_type"]
+    sub = metrics["per_type"]["SubClassOf"]
+    assert sub["precision"] == pytest.approx(1.0)
+    assert sub["recall"] == pytest.approx(1.0)
+


### PR DESCRIPTION
## Summary
- extend axiom metrics to detect owl:equivalentClass
- allow scoring equivalence either as SubClassOf pairs or in an EquivalentClasses bucket via `--equiv-as-subclass`
- include equivalence handling in macro-average and add tests for both modes

## Testing
- `pytest tests/test_axiom_metrics.py tests/test_evaluation_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b180367f908330928e3d59f8f0a014