### PR TITLE
Evaluate domain and range axioms

### DIFF
--- a/evaluation/axiom_metrics.py
+++ b/evaluation/axiom_metrics.py
@@ -24,7 +24,7 @@ except Exception:  # pragma: no cover - owlrl is optional at runtime
     OWLRL_Semantics = None
 
 # Type alias for sets of axioms represented as hashable tuples or nodes
-NormalizedAxiom = Union[str, Tuple[str, str]]
+NormalizedAxiom = Union[str, Tuple[str, ...]]
 AxiomSet = Set[NormalizedAxiom]
 
 # Mapping axiom type names to callables extracting corresponding sets from a graph
@@ -33,8 +33,8 @@ AXIOM_EXTRACTORS = {
     "ObjectProperty": lambda g: set(g.subjects(RDF.type, OWL.ObjectProperty)),
     "DatatypeProperty": lambda g: set(g.subjects(RDF.type, OWL.DatatypeProperty)),
     "SubClassOf": lambda g: set(g.subject_objects(RDFS.subClassOf)),
-    "Domain": lambda g: set(g.subject_objects(RDFS.domain)),
-    "Range": lambda g: set(g.subject_objects(RDFS.range)),
+    "Domain": lambda g: set(g.triples((None, RDFS.domain, None))),
+    "Range": lambda g: set(g.triples((None, RDFS.range, None))),
 }
 
 

--- a/tests/test_axiom_metrics.py
+++ b/tests/test_axiom_metrics.py
@@ -37,3 +37,44 @@ def test_equivalent_classes_as_subclass():
     assert sub["precision"] == pytest.approx(1.0)
     assert sub["recall"] == pytest.approx(1.0)
 
+
+def test_domain_and_range_metrics():
+    g_pred = Graph()
+    g_pred.parse(
+        data=(
+            "@prefix : <http://example.com/> .\n"
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n"
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+            ":p a owl:ObjectProperty ;\n"
+            "    rdfs:domain :A ;\n"
+            "    rdfs:range :B ."
+        ),
+        format="turtle",
+    )
+
+    g_gold = Graph()
+    g_gold.parse(
+        data=(
+            "@prefix : <http://example.com/> .\n"
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n"
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+            ":p a owl:ObjectProperty ;\n"
+            "    rdfs:domain :A ;\n"
+            "    rdfs:range :C ."
+        ),
+        format="turtle",
+    )
+
+    metrics = evaluate_axioms(g_pred, g_gold)
+    dom = metrics["per_type"]["Domain"]
+    rng = metrics["per_type"]["Range"]
+
+    assert dom["precision"] == pytest.approx(1.0)
+    assert dom["recall"] == pytest.approx(1.0)
+    assert rng["precision"] == pytest.approx(0.0)
+    assert rng["recall"] == pytest.approx(0.0)
+
+    # macro-F1 should include Domain and Range axiom types
+    expected_macro = (1 + 1) / 7  # two types with F1=1 out of seven
+    assert metrics["macro_f1"] == pytest.approx(expected_macro)
+


### PR DESCRIPTION
## Summary
- evaluate `rdfs:domain` and `rdfs:range` triples in axiom metrics
- include domain and range scores in macro-averaged results
- add regression test for domain/range metrics

## Testing
- `pytest tests/test_axiom_metrics.py tests/test_evaluation_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b18144ebec8330a146380d881e75dd