### PR TITLE
Add SHACL validation summary metrics and update interfaces

### DIFF
--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -226,7 +226,7 @@ class RepairLoop:
         initial_count = 0
         while True:
             validator = SHACLValidator(current_data, self.shapes_path, inference=inference)
-            conforms, violations = validator.run_validation()
+            conforms, violations, _ = validator.run_validation()
             if k == 0:
                 initial_count = len(violations)
             final_violations = violations

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -226,7 +226,7 @@ def run_pipeline(
 
     if validate:
         validator = SHACLValidator(pipeline["combined_ttl"], shapes, inference=inference)
-        conforms, report = validator.run_validation()
+        conforms, report, summary = validator.run_validation()
         logger.info("Conforms: %s", conforms)
         logger.info("SHACL Report: %s", report)
         shacl_report_path = "results/shacl_report.txt"
@@ -235,6 +235,7 @@ def run_pipeline(
         pipeline["shacl_conforms"] = conforms
         pipeline["shacl_report"] = report
         pipeline["shacl_report_path"] = shacl_report_path
+        pipeline["shacl_summary"] = summary
 
         if not conforms and repair:
             logger.info("Running repair loop...")

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -45,18 +45,22 @@ atm:alice atm:knows atm:bob .""",
         def run_validation(self):
             FakeValidator.runs.append(self.data_path)
             if len(FakeValidator.runs) == 1:
-                return False, [
-                    {
-                        "focusNode": "http://example.com/atm#alice",
-                        "resultPath": "http://example.com/atm#knows",
-                        "message": "error",
-                        "sourceShape": "ex:Shape",
-                        "sourceConstraintComponent": "sh:MinCountConstraintComponent",
-                        "expected": "1",
-                        "value": "http://example.com/atm#bob",
-                    }
-                ]
-            return True, []
+                return (
+                    False,
+                    [
+                        {
+                            "focusNode": "http://example.com/atm#alice",
+                            "resultPath": "http://example.com/atm#knows",
+                            "message": "error",
+                            "sourceShape": "ex:Shape",
+                            "sourceConstraintComponent": "sh:MinCountConstraintComponent",
+                            "expected": "1",
+                            "value": "http://example.com/atm#bob",
+                        }
+                    ],
+                    {"total": 1, "bySeverity": {}, "byShapePath": {}},
+                )
+            return True, [], {"total": 0, "bySeverity": {}, "byShapePath": {}}
 
     monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
     monkeypatch.setattr(repair_loop, "run_reasoner", lambda path: (None, []))

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -158,7 +158,7 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
             self.inference = inference
 
         def run_validation(self):
-            return False, "report"
+            return False, "report", {}
 
     monkeypatch.setattr(main, "SHACLValidator", FakeValidator)
 
@@ -233,7 +233,7 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
             pass
 
         def run_validation(self):
-            return False, "report"
+            return False, "report", {}
 
     monkeypatch.setattr(main, "SHACLValidator", FakeValidator)
 


### PR DESCRIPTION
## Summary
- enhance `SHACLValidator.run_validation` to deduplicate violations and produce summary metrics
- propagate new `(conforms, results, summary)` return signature to repair loop and pipeline
- adjust tests for new validation summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b18607c7148330bfa87440eaed3278