### PR TITLE
Report ontology consistency from run_reasoner

### DIFF
--- a/ontology_guided/reasoner.py
+++ b/ontology_guided/reasoner.py
@@ -25,21 +25,26 @@ def run_reasoner(owl_path: str = "results/combined.owl"):
     Returns
     -------
     tuple
-        The loaded ontology and a list of IRIs for inconsistent classes.
+        ``(ontology, is_consistent, unsatisfiable_iris)`` where ``ontology`` is
+        the loaded ontology, ``is_consistent`` indicates whether the ontology is
+        logically consistent, and ``unsatisfiable_iris`` is a list of IRIs for
+        unsatisfiable classes.
     """
     if not os.path.exists(owl_path):
         raise FileNotFoundError(f"{owl_path} not found")
 
     onto = get_ontology("file://" + os.path.abspath(owl_path)).load()
-    inconsistent: list = []
+    is_consistent = True
+    unsat_classes: list = []
     try:
         with onto:
             sync_reasoner()
-            inconsistent = list(onto.world.inconsistent_classes())
+            is_consistent = not getattr(onto.world, "inconsistent", False)
+            unsat_classes = list(onto.world.inconsistent_classes())
     except OwlReadyJavaError as exc:
         raise ReasonerError(
             "Java runtime not found; install Java to enable reasoning"
         ) from exc
-    for cls in inconsistent:
+    for cls in unsat_classes:
         logger.warning("Inconsistent class: %s", cls.iri)
-    return onto, [c.iri for c in inconsistent]
+    return onto, is_consistent, [c.iri for c in unsat_classes]

--- a/ontology_guided/repair_loop.py
+++ b/ontology_guided/repair_loop.py
@@ -272,7 +272,7 @@ class RepairLoop:
             try:
                 temp_owl = os.path.join("results", f"pre_reason_{k}.owl")
                 temp_builder.save(temp_owl, fmt="xml")
-                _, inconsistent = run_reasoner(temp_owl)
+                _, _, inconsistent = run_reasoner(temp_owl)
             except ReasonerError as exc:
                 logger.warning("Reasoner failed: %s", exc)
 
@@ -339,7 +339,7 @@ class RepairLoop:
             self.builder.save(owl_path, fmt="xml")
             if reason:
                 try:
-                    _, inconsistent = run_reasoner(owl_path)
+                    _, _, inconsistent = run_reasoner(owl_path)
                     inc_path = os.path.join(
                         "results", f"inconsistent_classes_{k + 1}.txt"
                     )

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -211,7 +211,7 @@ def run_pipeline(
         try:
             from ontology_guided.reasoner import run_reasoner
 
-            _, inconsistent = run_reasoner(pipeline["combined_owl"])
+            _, _, inconsistent = run_reasoner(pipeline["combined_owl"])
             inconsistent_path = os.path.join("results", "inconsistent_classes.txt")
             with open(inconsistent_path, "w", encoding="utf-8") as f:
                 for iri in inconsistent:

--- a/tests/test_reasoner.py
+++ b/tests/test_reasoner.py
@@ -16,11 +16,13 @@ def test_run_reasoner(tmp_path):
     onto.save(file=str(owl_path))
 
     try:
-        result, inconsistent = run_reasoner(str(owl_path))
+        result, is_consistent, inconsistent = run_reasoner(str(owl_path))
     except ReasonerError as exc:
         pytest.skip(str(exc))
         return
 
+    assert is_consistent
     assert inconsistent == []
     names = {c.name for c in result.classes()}
     assert {"A", "B"}.issubset(names)
+

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -64,7 +64,7 @@ atm:alice atm:knows atm:bob .""",
             return True, [], {"total": 0, "bySeverity": {}, "byShapePath": {}}
 
     monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
-    monkeypatch.setattr(repair_loop, "run_reasoner", lambda path: (None, []))
+    monkeypatch.setattr(repair_loop, "run_reasoner", lambda path: (None, True, []))
 
     repairer = RepairLoop(str(data_path), str(shapes_path), api_key="dummy")
     ttl_path, report_path, violations, stats = repairer.run()
@@ -322,7 +322,7 @@ def test_repair_loop_logs_metrics_and_reduction(monkeypatch, tmp_path, caplog):
             return True, [], {"total": 0, "bySeverity": {}, "byShapePath": {}}
 
     monkeypatch.setattr(repair_loop, "SHACLValidator", FakeValidator)
-    monkeypatch.setattr(repair_loop, "run_reasoner", lambda path: (None, []))
+    monkeypatch.setattr(repair_loop, "run_reasoner", lambda path: (None, True, []))
 
     with caplog.at_level(logging.INFO):
         repairer = RepairLoop(str(data_path), str(shapes_path), api_key="dummy")

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -306,7 +306,7 @@ def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):
 
     def fake_run_reasoner(path):
         called["path"] = path
-        return None, []
+        return None, True, []
 
     import ontology_guided.reasoner as reasoner
 


### PR DESCRIPTION
## Summary
- Expand `run_reasoner` to return a boolean indicating consistency and IRIs of unsatisfiable classes
- Adjust repair loop and pipeline to consume new `(ontology, is_consistent, unsat_classes)` tuple
- Update tests for revised reasoner interface

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1890434608330a5198cae9bfd8d93