### PR TITLE
Ensure tests handle new reasoner tuple

### DIFF
--- a/tests/test_reasoner.py
+++ b/tests/test_reasoner.py
@@ -16,13 +16,13 @@ def test_run_reasoner(tmp_path):
     onto.save(file=str(owl_path))
 
     try:
-        result, is_consistent, inconsistent = run_reasoner(str(owl_path))
+        onto, is_consistent, unsats = run_reasoner(str(owl_path))
     except ReasonerError as exc:
         pytest.skip(str(exc))
         return
 
     assert is_consistent
-    assert inconsistent == []
-    names = {c.name for c in result.classes()}
+    assert unsats == []
+    names = {c.name for c in onto.classes()}
     assert {"A", "B"}.issubset(names)
 

--- a/tests/test_repair_loop.py
+++ b/tests/test_repair_loop.py
@@ -80,6 +80,10 @@ atm:alice atm:knows atm:bob .""",
     assert stats["first_conforms_iteration"] == 1
     assert stats["per_iteration"][0]["total"] == 1
     assert stats["per_iteration"][1]["total"] == 0
+    assert stats["per_iteration"][0]["is_consistent"] is True
+    assert stats["per_iteration"][0]["unsat_count"] == 0
+    assert stats["per_iteration"][1]["is_consistent"] is True
+    assert stats["per_iteration"][1]["unsat_count"] == 0
 
     report0 = tmp_path / "results" / "report_0.txt"
     content = report0.read_text(encoding="utf-8").strip()

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -329,3 +329,5 @@ def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):
     assert result["reasoning_log"] == "Reasoner completed successfully"
     assert result["inconsistent_classes"]["iris"] == []
     assert pathlib.Path(result["inconsistent_classes"]["path"]).exists()
+    assert result["inconsistent_classes"]["count"] == 0
+    assert result["is_consistent"] is True


### PR DESCRIPTION
## Summary
- Update unit tests to unpack `(onto, is_consistent, unsats)` from `run_reasoner`
- Assert consistency and unsatisfiable-class counts in pipeline and repair loop tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b18d027f10833088e79bf699902cbe