### PR TITLE
Add competency question evaluation support

### DIFF
--- a/evaluation/atm_cqs.rq
+++ b/evaluation/atm_cqs.rq
@@ -1,0 +1,15 @@
+PREFIX atm: <http://lod.csd.auth.gr/atm/atm.ttl#>
+
+# Every Withdrawal has a non-negative amount
+ASK {
+  FILTER NOT EXISTS {
+    ?w a atm:Withdrawal ;
+       atm:amount ?amt .
+    FILTER (?amt < 0)
+  }
+}
+
+# ATMs accept cash cards
+ASK {
+  atm:ATM atm:accepts ?card .
+}

--- a/evaluation/competency_questions.py
+++ b/evaluation/competency_questions.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Utilities to evaluate competency questions over generated ontologies.
+
+The main entry point ``evaluate_cqs`` loads a list of SPARQL ASK queries from a
+file, executes them against an ontology graph after optional OWL RL reasoning
+and reports how many queries evaluate to ``True``.
+"""
+
+from pathlib import Path
+from typing import List, Dict, Union
+import json
+
+from rdflib import Graph
+
+try:  # Optional reasoning
+    from owlrl import DeductiveClosure, OWLRL_Semantics
+except Exception:  # pragma: no cover - owlrl is optional
+    DeductiveClosure = None
+    OWLRL_Semantics = None
+
+
+def _load_queries(path: Union[str, Path]) -> List[str]:
+    """Return a list of SPARQL ASK queries from ``path``.
+
+    Supports JSON files containing either a list of query strings or a dict with
+    a ``"queries"`` key.  For ``.rq``/text files, queries are expected to be
+    separated by blank lines.
+    """
+
+    path = Path(path)
+    if path.suffix in {".json", ".jsonl"}:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            queries = data.get("queries", [])
+        elif isinstance(data, list):
+            queries = data
+        else:  # pragma: no cover - invalid structure
+            raise ValueError("JSON file must contain a list or a 'queries' key")
+    else:
+        text = path.read_text(encoding="utf-8")
+        queries = [q.strip() for q in text.split("\n\n") if q.strip()]
+    return queries
+
+
+def evaluate_cqs(
+    ontology_path: Union[str, Path],
+    cq_path: Union[str, Path],
+    inference: bool = True,
+) -> Dict[str, Union[int, float]]:
+    """Evaluate competency questions against ``ontology_path``.
+
+    Parameters
+    ----------
+    ontology_path:
+        Path to a Turtle file representing the ontology.
+    cq_path:
+        File containing SPARQL ``ASK`` queries.
+    inference:
+        If ``True`` (default) and :mod:`owlrl` is available, the ontology graph
+        is expanded using OWL RL reasoning before queries are executed.
+
+    Returns
+    -------
+    Dict[str, Union[int, float]]
+        Dictionary with ``passed`` (number of queries evaluating to ``True``),
+        ``total`` (total number of queries) and ``pass_rate``.
+    """
+
+    g = Graph()
+    g.parse(str(ontology_path), format="turtle")
+
+    if inference and DeductiveClosure is not None:
+        DeductiveClosure(OWLRL_Semantics).expand(g)
+
+    queries = _load_queries(cq_path)
+    passed = 0
+    for q in queries:
+        try:
+            if bool(g.query(q)):
+                passed += 1
+        except Exception:  # pragma: no cover - malformed query
+            continue
+    total = len(queries)
+    rate = passed / total if total else 0.0
+    return {"passed": passed, "total": total, "pass_rate": rate}
+
+
+__all__ = ["evaluate_cqs"]

--- a/evaluation/healthcare_cqs.rq
+++ b/evaluation/healthcare_cqs.rq
@@ -1,0 +1,17 @@
+PREFIX hc: <http://example.com/healthcare#>
+
+# Every Observation is performed by a Doctor
+ASK {
+  FILTER NOT EXISTS {
+    ?o a hc:Observation ;
+       hc:performedBy ?x .
+    FILTER NOT EXISTS { ?x a hc:Doctor }
+  }
+}
+
+# Observations concern Patients
+ASK {
+  ?o a hc:Observation ;
+     hc:onPatient ?p .
+  ?p a hc:Patient .
+}


### PR DESCRIPTION
## Summary
- add utility to execute SPARQL competency questions with optional reasoning
- allow run_benchmark to incorporate CQ pass rates via `--cq-file`
- include example CQ files for ATM and healthcare datasets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b18e605dbc8330b2685b9fe6242c41