### PR TITLE
Add competency questions evaluation test

### DIFF
--- a/tests/test_competency_questions.py
+++ b/tests/test_competency_questions.py
@@ -1,0 +1,32 @@
+import textwrap
+import pytest
+
+from evaluation.competency_questions import evaluate_cqs
+
+
+def test_evaluate_cqs_pass_rate(tmp_path):
+    ttl = textwrap.dedent(
+        """
+        @prefix : <http://example.org/> .
+        :Alice a :Person .
+        """
+    ).strip()
+    onto_path = tmp_path / "onto.ttl"
+    onto_path.write_text(ttl, encoding="utf-8")
+
+    queries = textwrap.dedent(
+        """
+        PREFIX : <http://example.org/>
+        ASK { :Alice a :Person . }
+
+        PREFIX : <http://example.org/>
+        ASK { :Bob a :Person . }
+        """
+    ).strip()
+    cq_path = tmp_path / "cqs.rq"
+    cq_path.write_text(queries, encoding="utf-8")
+
+    results = evaluate_cqs(onto_path, cq_path, inference=False)
+    assert results["passed"] == 1
+    assert results["total"] == 2
+    assert results["pass_rate"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add unit test verifying competency question pass-rate calculation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b190395a448330ba629a7935661025