### PR TITLE
Add tests for repair efficiency metrics

### DIFF
--- a/tests/test_repair_efficiency.py
+++ b/tests/test_repair_efficiency.py
@@ -1,0 +1,41 @@
+import evaluation.repair_efficiency as reff
+
+
+def test_aggregate_repair_efficiency_with_prompt_data():
+    """Ensure mean iterations and bucket distribution are computed correctly."""
+    # Simulate outputs from RepairLoop with known prompt stats
+    stats_list = [
+        {
+            "iterations": 1,
+            "first_conforms_iteration": 1,
+            "prompt_count": 2,
+            "prompt_success_rate": 0.5,
+        },
+        {
+            "iterations": 2,
+            "first_conforms_iteration": 2,
+            "prompt_count": 4,
+            "prompt_success_rate": 0.5,
+        },
+        {
+            "iterations": 3,
+            "first_conforms_iteration": 3,
+            "prompt_count": 6,
+            "prompt_success_rate": 0.5,
+        },
+        {
+            "iterations": 4,
+            "first_conforms_iteration": 4,
+            "prompt_count": 8,
+            "prompt_success_rate": 0.5,
+        },
+    ]
+
+    efficiency = reff.aggregate_repair_efficiency(stats_list)
+
+    assert efficiency.case_count == 4
+    assert efficiency.mean_iterations == 2.5
+    assert efficiency.distribution == {"1": 1, "2": 1, "3": 1, ">3": 1}
+    assert efficiency.avg_prompts_per_iteration == 2.0
+    # Success rate cannot be derived from prompt_success_rate alone
+    assert efficiency.success_rate_per_prompt is None

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -183,6 +183,8 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
                     "first_conforms_iteration": 1,
                     "per_iteration": [],
                     "reduction": 1.0,
+                    "prompt_count": 2,
+                    "prompt_success_rate": 0.5,
                 },
             )
 
@@ -216,6 +218,8 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
     assert stats["pre_count"] == 1
     assert stats["post_count"] == 0
     assert stats["iterations"] == 1
+    assert stats["prompt_count"] == 2
+    assert stats["prompt_success_rate"] == 0.5
 
 
 def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
@@ -259,6 +263,8 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
                     "first_conforms_iteration": 0,
                     "per_iteration": [],
                     "reduction": 0.0,
+                    "prompt_count": 0,
+                    "prompt_success_rate": 0.0,
                 },
             )
 
@@ -284,6 +290,8 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
     assert stats["pre_count"] == 0
     assert stats["post_count"] == 0
     assert stats["iterations"] == 0
+    assert stats["prompt_count"] == 0
+    assert stats["prompt_success_rate"] == 0.0
 
 
 def test_run_pipeline_runs_reasoner(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add aggregation test verifying repair efficiency metrics and prompt handling
- ensure run_pipeline collects prompt_count and prompt_success_rate in violation stats

## Testing
- `pytest tests/test_repair_efficiency.py tests/test_run_pipeline.py::test_run_pipeline_passes_repair_options tests/test_run_pipeline.py::test_run_pipeline_skips_repaired_ttl_when_none -q`

------
https://chatgpt.com/codex/tasks/task_e_68b195704c64833097504edd80d7b9ac