### PR TITLE
Add mini evaluation example for withdrawal scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ python -m evaluation.run_benchmark \
     --settings '[{"name":"table1","use_terms":true,"validate":true,"ontologies":["ontologies/rbo.ttl","ontologies/lexical.ttl"]}]'
 ```
 
+### Mini Evaluation Example
+
+Για ένα μίνι παράδειγμα, χρησιμοποιήστε τα αρχεία στον φάκελο `evaluation` που ξεκινούν με `mini_`.
+Τρέξτε:
+```bash
+python3 evaluation/compare_metrics.py evaluation/mini_requirements.jsonl evaluation/mini_gold.ttl --shapes evaluation/mini_shapes.ttl --base-iri http://example.com/mini#
+```
+Αναμένονται μετρικές F1 περίπου 0.14 → 0.27 → 0.53 για τα αρχεία `mini_pred_iter0.ttl`, `mini_pred_iter1.ttl` και `mini_pred_iter2.ttl`.
+
 ### Competency Questions
 
 Οι ερωτήσεις ικανότητας (Competency Questions) μετρούν κατά πόσο η παραγόμενη

--- a/evaluation/mini_gold.ttl
+++ b/evaluation/mini_gold.ttl
@@ -1,0 +1,23 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Class hierarchy
+ex:Withdrawal rdfs:subClassOf ex:Transaction .
+
+# Property domains and ranges
+ex:performedBy a owl:ObjectProperty ;
+  rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:hasAmount a owl:DatatypeProperty ;
+  rdfs:domain ex:Transaction ;
+  rdfs:range xsd:decimal .
+
+# Example individuals
+ex:c1 a ex:Customer .
+ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "100"^^xsd:decimal .

--- a/evaluation/mini_pred_iter0.ttl
+++ b/evaluation/mini_pred_iter0.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:atm1 .
+
+ex:atm1 a ex:ATM .

--- a/evaluation/mini_pred_iter1.ttl
+++ b/evaluation/mini_pred_iter1.ttl
@@ -1,0 +1,8 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:atm1 ;
+  ex:hasAmount "100"^^xsd:decimal .
+
+ex:atm1 a ex:ATM .

--- a/evaluation/mini_pred_iter2.ttl
+++ b/evaluation/mini_pred_iter2.ttl
@@ -1,0 +1,8 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "100"^^xsd:decimal .
+
+ex:c1 a ex:Customer .

--- a/evaluation/mini_requirements.jsonl
+++ b/evaluation/mini_requirements.jsonl
@@ -1,0 +1,1 @@
+{"title": "Mini Requirement 1", "text": "A withdrawal is performed by a customer with an amount."}

--- a/evaluation/mini_shapes.ttl
+++ b/evaluation/mini_shapes.ttl
@@ -1,0 +1,16 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:WithdrawalShape a sh:NodeShape ;
+  sh:targetClass ex:Withdrawal ;
+  sh:property [
+    sh:path ex:performedBy ;
+    sh:class ex:Customer ;
+    sh:minCount 1 ;
+  ] ;
+  sh:property [
+    sh:path ex:hasAmount ;
+    sh:datatype xsd:decimal ;
+    sh:minCount 1 ;
+  ] .


### PR DESCRIPTION
## Summary
- Add minimal requirement JSON and matching gold ontology for a withdrawal performed by a customer with an amount
- Supply SHACL shape and sample prediction TTLs showing iterative repairs
- Document the mini example and how to run metrics in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b198a08540833097cf1dcb09873651