### PR TITLE
Add competency question evaluation to mini example

### DIFF
--- a/evaluation/mini_cqs.rq
+++ b/evaluation/mini_cqs.rq
@@ -1,0 +1,20 @@
+PREFIX ex: <http://example.com/mini#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+ASK WHERE {
+  FILTER NOT EXISTS {
+    ?w a ex:Withdrawal ;
+       ex:hasAmount ?amount .
+    FILTER (?amount < "0"^^xsd:decimal)
+  }
+}
+
+PREFIX ex: <http://example.com/mini#>
+ASK WHERE {
+  FILTER NOT EXISTS {
+    ?w a ex:Withdrawal .
+    FILTER NOT EXISTS {
+      ?w ex:performedBy ?c .
+      ?c a ex:Customer .
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add sample SPARQL competency questions for the mini example
- run competency question evaluation during each iteration and report pass counts
- handle reasoning errors gracefully

## Testing
- `pytest tests/test_competency_questions.py -q`
- `python evaluation/mini_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68b19bbbcd40833088947236d2802e6f