### PR TITLE
Add simplified ATM evaluation dataset

### DIFF
--- a/evaluation/atm_gold1.ttl
+++ b/evaluation/atm_gold1.ttl
@@ -1,58 +1,1403 @@
-@prefix atm: <http://lod.csd.auth.gr/atm/atm.ttl#> .
+@prefix : <http://lod.csd.auth.gr/atm/atm.ttl#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-# Class hierarchy
-atm:Withdrawal rdfs:subClassOf atm:ATMTransaction .
-
-# Object properties
-atm:belongsToBank a owl:ObjectProperty ;
-  rdfs:domain atm:ATM ;
-  rdfs:range atm:Bank .
-
-atm:hasCashCard a owl:ObjectProperty ;
-  rdfs:domain atm:Customer ;
-  rdfs:range atm:CashCard .
-
-atm:holds a owl:ObjectProperty ;
-  rdfs:domain atm:Customer ;
-  rdfs:range atm:Account .
-
-atm:involves a owl:ObjectProperty ;
-  rdfs:domain atm:CashCard ;
-  rdfs:range atm:Account .
-
-atm:accepts a owl:ObjectProperty ;
-  rdfs:domain atm:ATM ;
-  rdfs:range atm:CashCard .
-
-atm:isLinkedToATM a owl:ObjectProperty ;
-  rdfs:domain atm:ATMTransaction ;
-  rdfs:range atm:ATM .
-
-atm:isLinkedTo a owl:ObjectProperty ;
-  rdfs:domain atm:ATMTransaction ;
-  rdfs:range atm:Account .
-
-# Example individuals
-atm:bank1 a atm:Bank .
-
-atm:atm1 a atm:ATM ;
-  atm:belongsToBank atm:bank1 ;
-  atm:accepts atm:card1 .
-
-atm:customer1 a atm:Customer ;
-  atm:hasCashCard atm:card1 ;
-  atm:holds atm:account1 .
-
-atm:card1 a atm:CashCard ;
-  atm:involves atm:account1 .
-
-atm:account1 a atm:Account .
-
-atm:withdrawal1 a atm:Withdrawal ;
-  atm:isLinkedToATM atm:atm1 ;
-  atm:isLinkedTo atm:account1 .
-
+@prefix xsp: <http://www.owl-ontologies.com/2005/08/07/xsp.owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix swrl: <http://www.w3.org/2003/11/swrl#> .
+@prefix swrlb: <http://www.w3.org/2003/11/swrlb#> .
+@prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .
+@base <http://lod.csd.auth.gr/atm/atm.ttl#> .
+<http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .
+:accepts rdf:type owl:ObjectProperty ;
+         rdfs:domain :ATM ;
+         rdfs:range :CashCard ;
+         owl:propertyDisjointWith :not_accepts .
+:belongsToBank rdf:type owl:ObjectProperty ;
+               owl:inverseOf :isBelongedBy ;
+               rdfs:domain :ATM ;
+               rdfs:range [ rdf:type owl:Restriction ;
+                            owl:onProperty :belongsToBank ;
+                            owl:allValuesFrom :Bank
+                          ] .
+:belongsToCashCard rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf owl:topObjectProperty ;
+                   rdfs:domain :CashCard ;
+                   rdfs:range [ rdf:type owl:Restriction ;
+                                owl:onProperty :belongsToCashCard ;
+                                owl:allValuesFrom :Customer
+                              ] .
+:complies_with rdf:type owl:ObjectProperty ;
+               rdfs:domain :Function ;
+               rdfs:range :InformationStandard .
+:condition rdf:type owl:ObjectProperty ;
+           rdfs:domain :ComplexRequirement ;
+           rdfs:range :BasicRequirement .
+:consistOfBankComputer rdf:type owl:ObjectProperty ;
+                       rdfs:domain :Bank ;
+                       rdfs:range [ rdf:type owl:Restriction ;
+                                    owl:onProperty :consistOfBankComputer ;
+                                    owl:someValuesFrom :BankComputer
+                                  ] .
+:consistOfKeys rdf:type owl:ObjectProperty ;
+               owl:inverseOf :ispartOfKeypad ;
+               rdfs:domain :Keypad ;
+               rdfs:range :Keys .
+:dispenses rdf:type owl:ObjectProperty ;
+           rdfs:domain :ATM ;
+           rdfs:range :Money .
+:displays rdf:type owl:ObjectProperty ;
+          rdfs:domain :ATM ;
+          rdfs:range [ rdf:type owl:Class ;
+                       owl:unionOf ( :ErrorDisplay
+                                     :NormalDisplay
+                                   )
+                     ] .
+:else rdf:type owl:ObjectProperty ;
+      rdfs:domain :ComplexRequirement ;
+      rdfs:range :BasicRequirement .
+:enters rdf:type owl:ObjectProperty ;
+        rdfs:domain :Customer ;
+        rdfs:range [ rdf:type owl:Class ;
+                     owl:unionOf ( :CashCard
+                                   :TransactionAmountOfTransaction
+                                 )
+                   ] .
+:forTime rdf:type owl:ObjectProperty ;
+         rdfs:domain :Display ;
+         rdfs:range :DisplayTime .
+:fromATM rdf:type owl:ObjectProperty ;
+         rdfs:domain [ rdf:type owl:Class ;
+                       owl:unionOf ( :TransactionAmountOfTransactionFromATM
+                                     :TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM
+                                   )
+                     ] ;
+         rdfs:range :ATM .
+:fromBankComputer rdf:type owl:ObjectProperty ;
+                  rdfs:domain [ rdf:type owl:Class ;
+                                owl:unionOf ( :InteractionFromBankComputer
+                                              :ResponseFromBankComputer
+                                              :StatusInteractionFromBankComputer
+                                            )
+                              ] ;
+                  rdfs:range :BankComputer .
+:hasAccountBalanceDisplayTime rdf:type owl:ObjectProperty ;
+                              rdfs:domain :ATM ;
+                              rdfs:range :Time .
+:hasAccountBalanceTransferTime rdf:type owl:ObjectProperty ;
+                               rdfs:domain :ATM ;
+                               rdfs:range :Time .
+:hasBackUpPowerSupply rdf:type owl:ObjectProperty ;
+                      rdfs:domain :ATM ;
+                      rdfs:range :PowerSupply .
+:hasButtonResponseTime rdf:type owl:ObjectProperty ;
+                       rdfs:domain :ATM ;
+                       rdfs:range :Time .
+:hasCardVerificationTime rdf:type owl:ObjectProperty ;
+                         rdfs:domain :ATM ;
+                         rdfs:range :Time .
+:hasCashCard rdf:type owl:ObjectProperty ;
+             rdfs:domain :Customer ;
+             rdfs:range :CashCard .
+:hasCashWithdrawalTransactionTime rdf:type owl:ObjectProperty ;
+                                  rdfs:domain :ATM ;
+                                  rdfs:range :Time .
+:hasCost rdf:type owl:ObjectProperty ;
+         rdfs:domain :InternetAccess .
+:hasCreditCardAdvanceTime rdf:type owl:ObjectProperty ;
+                          rdfs:domain :ATM ;
+                          rdfs:range :Time .
+:hasCustomer rdf:type owl:ObjectProperty ,
+                      owl:IrreflexiveProperty ;
+             rdfs:domain :Bank ;
+             rdfs:range [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasCustomer ;
+                          owl:someValuesFrom :Customer
+                        ] .
+:hasDepositTransactionTime rdf:type owl:ObjectProperty ;
+                           rdfs:domain :ATM ;
+                           rdfs:range :Time .
+:hasDisplayTime rdf:type owl:ObjectProperty ;
+                rdfs:domain :ErrorDisplay ;
+                rdfs:range :TimeUnit .
+:hasFunctionalKey rdf:type owl:ObjectProperty ;
+                  rdfs:domain :Keypad ;
+                  rdfs:range [ rdf:type owl:Restriction ;
+                               owl:onProperty :hasFunctionalKey ;
+                               owl:qualifiedCardinality "8"^^xsd:nonNegativeInteger ;
+                               owl:onClass :Keys
+                             ] .
+:hasInitialDisplay rdf:type owl:ObjectProperty ;
+                   rdfs:domain :ATMTransaction ;
+                   rdfs:range :Display .
+:hasInput rdf:type owl:ObjectProperty ;
+          rdfs:domain :PowerSupply ;
+          rdfs:range :PowerSource .
+:hasMainPowerSupply rdf:type owl:ObjectProperty ;
+                    rdfs:domain :ATM ;
+                    rdfs:range :PowerSupply .
+:hasPinVerificationTime rdf:type owl:ObjectProperty ;
+                        rdfs:domain :ATM ;
+                        rdfs:range :Time .
+:hasProduct rdf:type owl:ObjectProperty ;
+            rdfs:domain :Customer ;
+            rdfs:range [ rdf:type owl:Restriction ;
+                         owl:onProperty :hasProduct ;
+                         owl:someValuesFrom :Product
+                       ] .
+:hasReceipt rdf:type owl:ObjectProperty ;
+            rdfs:domain :Printer ;
+            rdfs:range :Receipt .
+:hasReceiptPrintingTime rdf:type owl:ObjectProperty ;
+                        rdfs:domain :ATM ;
+                        rdfs:range :Time .
+:hasTouchScreenTime rdf:type owl:ObjectProperty ;
+                    rdfs:domain :ATM ;
+                    rdfs:range :Time .
+:hasUnit rdf:type owl:ObjectProperty ;
+         rdfs:domain :PhysicalQuantity ;
+         rdfs:range :Unit .
+:hasVolatge rdf:type owl:ObjectProperty ;
+            rdfs:domain :PowerSupply .
+:haskey rdf:type owl:ObjectProperty ;
+        rdfs:domain :Keypad ;
+        rdfs:range :Keys .
+:holds rdf:type owl:ObjectProperty ;
+       owl:inverseOf :isHold ;
+       rdfs:domain :Customer ;
+       rdfs:range :Account .
+:initializes rdf:type owl:ObjectProperty ;
+             rdfs:domain :Maintainer ;
+             rdfs:range :AccountMaxWithdrawalPerDayAndAccountOfAccount .
+:involves rdf:type owl:ObjectProperty ;
+          rdfs:domain :CashCard ;
+          rdfs:range [ rdf:type owl:Restriction ;
+                       owl:onProperty :involves ;
+                       owl:someValuesFrom :Account
+                     ] .
+:isBelongedBy rdf:type owl:ObjectProperty ;
+              rdfs:domain :Bank ;
+              rdfs:range [ rdf:type owl:Restriction ;
+                           owl:onProperty :isBelongedBy ;
+                           owl:someValuesFrom :ATM
+                         ] .
+:isHold rdf:type owl:ObjectProperty ;
+        rdfs:domain :Account ;
+        rdfs:range [ rdf:type owl:Restriction ;
+                     owl:onProperty :isHold ;
+                     owl:someValuesFrom :Customer
+                   ] .
+:isLessThan rdf:type owl:ObjectProperty ;
+            rdfs:domain :Money ;
+            rdfs:range :AccountMaxWithdrawalPerDayAndAccountOfAccount .
+:isLinkedTo rdf:type owl:ObjectProperty ;
+            rdfs:domain :ATMTransaction ;
+            rdfs:range :Account .
+:isLinkedToATM rdf:type owl:ObjectProperty ;
+               rdfs:domain :ATMTransaction ;
+               rdfs:range :ATM .
+:isLinkedToCard rdf:type owl:ObjectProperty ;
+                rdfs:domain :ATMTransaction ;
+                rdfs:range :Card .
+:isMaintained rdf:type owl:ObjectProperty ;
+              owl:inverseOf :maintains ;
+              rdfs:domain :ATM ;
+              rdfs:range [ rdf:type owl:Restriction ;
+                           owl:onProperty :isMaintained ;
+                           owl:someValuesFrom :Maintainer
+                         ] .
+:isPartOf rdf:type owl:ObjectProperty ;
+          rdfs:domain :Printer ;
+          rdfs:range :ATM .
+:isPartOfATM rdf:type owl:ObjectProperty ;
+             rdfs:domain :Screen ;
+             rdfs:range :ATM .
+:isPerformedByCustomer rdf:type owl:ObjectProperty ;
+                       rdfs:domain :ATMTransaction ;
+                       rdfs:range :Customer .
+:is_checking rdf:type owl:ObjectProperty ;
+             rdfs:domain [ rdf:type owl:Class ;
+                           owl:unionOf ( :ATM
+                                         :BankComputer
+                                       )
+                         ] ;
+             rdfs:range [ rdf:type owl:Class ;
+                          owl:unionOf ( :CardSerialNumberOfCashCard
+                                        :CashCard
+                                        :PasswordOfCustomer
+                                        :TypedPasswordOfCustomer
+                                      )
+                        ] .
+:is_greater_than rdf:type owl:ObjectProperty ;
+                 rdfs:domain [ rdf:type owl:Class ;
+                               owl:unionOf ( :AccountCountFailPinOfAccount
+                                             :TransactionAmountOfTransaction
+                                           )
+                             ] ;
+                 rdfs:range [ rdf:type owl:Class ;
+                              owl:unionOf ( :BankMaxWithdrawalPerTransactionOfBank
+                                            :Count
+                                          )
+                            ] .
+:is_in rdf:type owl:ObjectProperty ;
+       rdfs:domain [ rdf:type owl:Class ;
+                     owl:unionOf ( :CashCard
+                                   :Money
+                                 )
+                   ] ;
+       rdfs:range :ATM ;
+       owl:propertyDisjointWith :is_in_not .
+:is_in_not rdf:type owl:ObjectProperty ;
+           rdfs:domain [ rdf:type owl:Class ;
+                         owl:unionOf ( :CashCard
+                                       :Money
+                                     )
+                       ] ;
+           rdfs:range :ATM .
+:is_in_state rdf:type owl:ObjectProperty ;
+             owl:inverseOf :is_not_state ;
+             rdfs:domain [ rdf:type owl:Class ;
+                           owl:unionOf ( :ATM
+                                         :Authorization
+                                         :CashCard
+                                       )
+                         ] ;
+             rdfs:range :Status .
+:is_less_than_or_equals_to rdf:type owl:ObjectProperty ;
+                           rdfs:domain [ rdf:type owl:Class ;
+                                         owl:unionOf ( :Money
+                                                       :TransactionAmountOfTransaction
+                                                     )
+                                       ] ;
+                           rdfs:range [ rdf:type owl:Class ;
+                                        owl:unionOf ( :AccountMaxWithdrawalPerDayAndAccountOfAccount
+                                                      :BankMaxWithdrawalPerTransactionOfBank
+                                                    )
+                                      ] .
+:is_not_state rdf:type owl:ObjectProperty ;
+              rdfs:domain [ rdf:type owl:Class ;
+                            owl:unionOf ( :ATM
+                                          :CashCard
+                                          :Process
+                                        )
+                          ] ;
+              rdfs:range :Status .
+:ispartOfKeypad rdf:type owl:ObjectProperty ;
+                rdfs:domain :Keys ;
+                rdfs:range :Keypad .
+:isperformedByATMTransaction rdf:type owl:ObjectProperty ;
+                             rdfs:domain :Customer ;
+                             rdfs:range :ATMTransaction .
+:keeps rdf:type owl:ObjectProperty ;
+       rdfs:domain :ATM ;
+       rdfs:range :CashCard .
+:lockingSystemPartOf rdf:type owl:ObjectProperty ;
+                     rdfs:domain :LockingSystem ;
+                     rdfs:range :CashVault .
+:maintains rdf:type owl:ObjectProperty ;
+           rdfs:domain :Maintainer ;
+           rdfs:range :ATM .
+:not_accepts rdf:type owl:ObjectProperty ;
+             rdfs:domain :ATM ;
+             rdfs:range :CashCard .
+:not_equals rdf:type owl:ObjectProperty ;
+            rdfs:domain [ rdf:type owl:Class ;
+                          owl:unionOf ( :ReadableBankCodeOfCashCard
+                                        :TypedPasswordOfCustomer
+                                      )
+                        ] ;
+            rdfs:range [ rdf:type owl:Class ;
+                         owl:unionOf ( :BankCodeOfBank
+                                       :PasswordOfCustomer
+                                     )
+                       ] .
+:object rdf:type owl:ObjectProperty ;
+        rdfs:domain :BasicRequirement ;
+        rdfs:range :Object .
+:ofATM rdf:type owl:ObjectProperty ;
+       rdfs:domain :ATMtotalFundOfATM ;
+       rdfs:range :ATM .
+:ofAccount rdf:type owl:ObjectProperty ;
+           rdfs:domain [ rdf:type owl:Class ;
+                         owl:unionOf ( :AccountBalanceOFAccount
+                                       :AccountCountFailPinOfAccount
+                                       :AccountMaxWithdrawalPerDayAndAccountOfAccount
+                                     )
+                       ] ;
+           rdfs:range :Account .
+:ofBank rdf:type owl:ObjectProperty ;
+        rdfs:domain [ rdf:type owl:Class ;
+                      owl:unionOf ( :BankCodeOfBank
+                                    :BankMaxWithdrawalPerTransactionOfBank
+                                  )
+                    ] ;
+        rdfs:range :Bank .
+:ofCashCard rdf:type owl:ObjectProperty ;
+            rdfs:domain [ rdf:type owl:Class ;
+                          owl:unionOf ( :CardSerialNumberOfCashCard
+                                        :ReadableBankCodeOfCashCard
+                                        :TransactionAmountOfTransactionCardSerialNumberOfCashCard
+                                        :TransactionAmountOfTransactionCardSerialNumberOfCashCardToBankComputer
+                                        :TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM
+                                        :TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer
+                                      )
+                        ] ;
+            rdfs:range :CashCard .
+:ofCustomer rdf:type owl:ObjectProperty ;
+            rdfs:domain [ rdf:type owl:Class ;
+                          owl:unionOf ( :PasswordOfCustomer
+                                        :TypedPasswordOfCustomer
+                                        :TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM
+                                        :TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer
+                                        :TypedPasswordOfCustomerToBankComputer
+                                      )
+                        ] ;
+            rdfs:range :Customer .
+:ofEntity rdf:type owl:ObjectProperty ;
+          rdfs:domain :BasicRequirement ;
+          rdfs:range :OfEntity .
+:ofInteraction rdf:type owl:ObjectProperty ;
+               rdfs:domain [ rdf:type owl:Class ;
+                             owl:unionOf ( :InteractionFromBankComputer
+                                           :InteractionToATM
+                                           :StatusInteractionFromBankComputer
+                                           :StatusInteractionToATM
+                                         )
+                           ] ;
+               rdfs:range :Interaction .
+:ofResponse rdf:type owl:ObjectProperty ;
+            rdfs:domain :ResponseFromBankComputer ;
+            rdfs:range :Response .
+:ofStatus rdf:type owl:ObjectProperty ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :StatusInteractionFromBankComputer
+                                      :StatusInteractionToATM
+                                    )
+                      ] ;
+          rdfs:range :Status .
+:ofTransaction rdf:type owl:ObjectProperty ;
+               rdfs:domain [ rdf:type owl:Class ;
+                             owl:unionOf ( :TransactionAmountOfTransaction
+                                           :TransactionAmountOfTransactionCardSerialNumberOfCashCard
+                                           :TransactionAmountOfTransactionCardSerialNumberOfCashCardToBankComputer
+                                           :TransactionAmountOfTransactionFromATM
+                                           :TransactionAmountOfTransactionToBankComputer
+                                         )
+                           ] ;
+               rdfs:range :ATMTransaction .
+:prints rdf:type owl:ObjectProperty ;
+        rdfs:domain :ATM ;
+        rdfs:range :Receipt .
+:reads rdf:type owl:ObjectProperty ;
+       rdfs:domain :ATM ;
+       rdfs:range [ rdf:type owl:Class ;
+                    owl:unionOf ( :BankCodeOfBank
+                                  :CardSerialNumberOfCashCard
+                                )
+                  ] .
+:receives rdf:type owl:ObjectProperty ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :ATM
+                                      :BankComputer
+                                    )
+                      ] ;
+          rdfs:range [ rdf:type owl:Class ;
+                       owl:unionOf ( :InteractionFromBankComputer
+                                     :StatusInteractionFromBankComputer
+                                     :TransactionAmountOfTransactionFromATM
+                                     :TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM
+                                   )
+                     ] .
+:records rdf:type owl:ObjectProperty ;
+         rdfs:domain [ rdf:type owl:Class ;
+                       owl:unionOf ( :ATM
+                                     :BankComputer
+                                   )
+                     ] ;
+         rdfs:range [ rdf:type owl:Class ;
+                      owl:unionOf ( :CardSerialNumberOfCashCard
+                                    :TransactionAmountOfTransactionCardSerialNumberOfCashCard
+                                  )
+                    ] .
+:returns rdf:type owl:ObjectProperty ;
+         rdfs:domain :ATM ;
+         rdfs:range :CashCard .
+:sends rdf:type owl:ObjectProperty ;
+       rdfs:domain [ rdf:type owl:Class ;
+                     owl:unionOf ( :ATM
+                                   :BankComputer
+                                 )
+                   ] ;
+       rdfs:range [ rdf:type owl:Class ;
+                    owl:unionOf ( :InteractionToATM
+                                  :StatusInteractionToATM
+                                  :TransactionAmountOfTransactionCardSerialNumberOfCashCard
+                                  :TransactionAmountOfTransactionToBankComputer
+                                  :TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer
+                                  :TypedPasswordOfCustomerToBankComputer
+                                )
+                  ] .
+:shouldBeLogged rdf:type owl:ObjectProperty ;
+                rdfs:domain :CashCard .
+:subject rdf:type owl:ObjectProperty ;
+         rdfs:domain :BasicRequirement ;
+         rdfs:range :Subject .
+:toATM rdf:type owl:ObjectProperty ;
+       rdfs:domain [ rdf:type owl:Class ;
+                     owl:unionOf ( :InteractionToATM
+                                   :StatusInteractionToATM
+                                 )
+                   ] ;
+       rdfs:range :ATM .
+:toBankComputer rdf:type owl:ObjectProperty ;
+                rdfs:domain [ rdf:type owl:Class ;
+                              owl:unionOf ( :TransactionAmountOfTransactionCardSerialNumberOfCashCardToBankComputer
+                                            :TransactionAmountOfTransactionToBankComputer
+                                            :TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer
+                                            :TypedPasswordOfCustomerToBankComputer
+                                          )
+                            ] ;
+                rdfs:range :BankComputer .
+:toEntity rdf:type owl:ObjectProperty ;
+          rdfs:domain :BasicRequirement ;
+          rdfs:range :ToEntity .
+:types rdf:type owl:ObjectProperty ;
+       rdfs:domain :Customer ;
+       rdfs:range [ rdf:type owl:Class ;
+                    owl:unionOf ( :PasswordOfCustomer
+                                  :TransactionAmountOfTransaction
+                                )
+                  ] .
+:updates rdf:type owl:ObjectProperty ;
+         rdfs:domain [ rdf:type owl:Class ;
+                       owl:unionOf ( :ATM
+                                     :BankComputer
+                                   )
+                     ] ;
+         rdfs:range [ rdf:type owl:Class ;
+                      owl:unionOf ( :ATMtotalFundOfATM
+                                    :AccountBalanceOFAccount
+                                    :AccountCountFailPinOfAccount
+                                    :AccountMaxWithdrawalPerDayAndAccountOfAccount
+                                  )
+                    ] .
+:verb rdf:type owl:ObjectProperty ;
+      rdfs:domain :BasicRequirement ;
+      rdfs:range :Verb .
+:waits rdf:type owl:ObjectProperty ;
+       rdfs:domain :ATM ;
+       rdfs:range :ResponseFromBankComputer .
+:works rdf:type owl:ObjectProperty ;
+       rdfs:domain :Maintainer ;
+       rdfs:range :Bank .
+:aTMAccountBalanceDisplayTime rdf:type owl:DatatypeProperty ;
+                              rdfs:domain :ATM ;
+                              rdfs:range xsd:double .
+:aTMAddress rdf:type owl:DatatypeProperty ;
+            rdfs:domain :ATM ;
+            rdfs:range xsd:string .
+:aTMBankName rdf:type owl:DatatypeProperty ;
+             rdfs:domain :ATM ;
+             rdfs:range xsd:string .
+:aTMBranch rdf:type owl:DatatypeProperty ;
+           rdfs:domain :ATM ;
+           rdfs:range xsd:string .
+:aTMCardVerificationTime rdf:type owl:DatatypeProperty ;
+                         rdfs:domain :ATM ;
+                         rdfs:range xsd:double .
+:aTMCashCardId rdf:type owl:DatatypeProperty ;
+               rdfs:domain :ATM ;
+               rdfs:range xsd:string .
+:aTMId rdf:type owl:DatatypeProperty ;
+       rdfs:domain :ATM ;
+       rdfs:range xsd:string .
+:aTMName rdf:type owl:DatatypeProperty ;
+         rdfs:domain :ATM ;
+         rdfs:range xsd:string .
+:aTMPinVerificationTime rdf:type owl:DatatypeProperty ;
+                        rdfs:domain :ATM ;
+                        rdfs:range xsd:double .
+:aTMtotalFund rdf:type owl:DatatypeProperty ;
+              rdfs:domain [ rdf:type owl:Class ;
+                            owl:unionOf ( :ATM
+                                          :ATMtotalFundOfATM
+                                        )
+                          ] ;
+              rdfs:range xsd:integer .
+:accountBalance rdf:type owl:DatatypeProperty ;
+                rdfs:domain [ rdf:type owl:Class ;
+                              owl:unionOf ( :Account
+                                            :AccountBalanceOFAccount
+                                          )
+                            ] ;
+                rdfs:range xsd:double .
+:accountCountFailPin rdf:type owl:DatatypeProperty ;
+                     rdfs:domain :AccountCountFailPinOfAccount ;
+                     rdfs:range xsd:integer .
+:accountMaxWithdrawalPerDayAndAccount rdf:type owl:DatatypeProperty ;
+                                      rdfs:domain [ rdf:type owl:Class ;
+                                                    owl:unionOf ( :Account
+                                                                  :AccountMaxWithdrawalPerDayAndAccountOfAccount
+                                                                  :Maintainer
+                                                                  :Money
+                                                                )
+                                                  ] ;
+                                      rdfs:range xsd:integer .
+:accountNumber rdf:type owl:DatatypeProperty ;
+               rdfs:domain :Account ;
+               rdfs:range xsd:string .
+:accountType rdf:type owl:DatatypeProperty ;
+             rdfs:domain :Account ;
+             rdfs:range xsd:string .
+:address rdf:type owl:DatatypeProperty ;
+         rdfs:domain :PersonOrPhysicalEntity ;
+         rdfs:range xsd:string .
+:bankAddress rdf:type owl:DatatypeProperty ;
+             rdfs:domain :Bank ;
+             rdfs:range xsd:string .
+:bankCode rdf:type owl:DatatypeProperty ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :ATM
+                                      :BankCodeOfBank
+                                    )
+                      ] ;
+          rdfs:range xsd:integer .
+:bankMaxWithdrawalPerTransaction rdf:type owl:DatatypeProperty ;
+                                 rdfs:domain [ rdf:type owl:Class ;
+                                               owl:unionOf ( :BankMaxWithdrawalPerTransactionOfBank
+                                                             :Money
+                                                           )
+                                             ] ;
+                                 rdfs:range xsd:integer .
+:bankMinCashPerTransaction rdf:type owl:DatatypeProperty ;
+                           rdfs:domain :Bank ;
+                           rdfs:range xsd:integer .
+:bankName rdf:type owl:DatatypeProperty ;
+          rdfs:domain :Bank ;
+          rdfs:range xsd:string .
+:bankTotalFundStartOfDay rdf:type owl:DatatypeProperty ;
+                         rdfs:domain :Bank ;
+                         rdfs:range xsd:integer .
+:cardBankName rdf:type owl:DatatypeProperty ;
+              rdfs:domain :Card ;
+              rdfs:range xsd:string .
+:cardCvv rdf:type owl:DatatypeProperty ;
+         rdfs:domain :Card ;
+         rdfs:range xsd:integer .
+:cardExpiryDate rdf:type owl:DatatypeProperty ;
+                rdfs:domain :Card ;
+                rdfs:range xsd:dateTime .
+:cardId rdf:type owl:DatatypeProperty ;
+        rdfs:domain :Card ;
+        rdfs:range xsd:string .
+:cardSerialNumber rdf:type owl:DatatypeProperty ;
+                  rdfs:domain [ rdf:type owl:Class ;
+                                owl:unionOf ( :CardSerialNumberOfCashCard
+                                              :CashCard
+                                              :TransactionAmountOfTransactionCardSerialNumberOfCashCard
+                                              :TransactionAmountOfTransactionCardSerialNumberOfCashCardToBankComputer
+                                              :TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM
+                                              :TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer
+                                            )
+                              ] ;
+                  rdfs:range xsd:string .
+:cardType rdf:type owl:DatatypeProperty ;
+          rdfs:domain :Card ;
+          rdfs:range xsd:string .
+:city rdf:type owl:DatatypeProperty ;
+      rdfs:domain :PersonOrPhysicalEntity ;
+      rdfs:range xsd:string .
+:computerID rdf:type owl:DatatypeProperty ;
+            rdfs:domain :BankComputer ;
+            rdfs:range xsd:string .
+:computerType rdf:type owl:DatatypeProperty ;
+              rdfs:domain :BankComputer ;
+              rdfs:range xsd:string .
+:customerID rdf:type owl:DatatypeProperty ;
+            rdfs:domain :Customer ;
+            rdfs:range xsd:string .
+:dateOfBirth rdf:type owl:DatatypeProperty ;
+             rdfs:domain :PersonOrPhysicalEntity ;
+             rdfs:range xsd:dateTime .
+:display rdf:type owl:DatatypeProperty ;
+         rdfs:domain :Display ;
+         rdfs:range xsd:string .
+:dotMatrixPrinterColumn rdf:type owl:DatatypeProperty ;
+                        rdfs:domain :DotMatrixPrinter ;
+                        rdfs:range xsd:integer .
+:email rdf:type owl:DatatypeProperty ;
+       rdfs:domain :PersonOrPhysicalEntity ;
+       rdfs:range xsd:string .
+:employeeId rdf:type owl:DatatypeProperty ;
+            rdfs:domain :Employee ;
+            rdfs:range xsd:string .
+:firstName rdf:type owl:DatatypeProperty ;
+           rdfs:domain :PersonOrPhysicalEntity ;
+           rdfs:range xsd:string .
+:gender rdf:type owl:DatatypeProperty ;
+        rdfs:domain :PersonOrPhysicalEntity ;
+        rdfs:range xsd:string .
+:hasValue rdf:type owl:DatatypeProperty ;
+          rdfs:domain :PhysicalQuantity .
+:interactionTimeStamp rdf:type owl:DatatypeProperty ;
+                      rdfs:domain :Interaction ;
+                      rdfs:range xsd:dateTimeStamp .
+:internet_AccessFormCost rdf:type owl:DatatypeProperty ;
+                         rdfs:domain :InternetAccess .
+:lastName rdf:type owl:DatatypeProperty ;
+          rdfs:domain :PersonOrPhysicalEntity ;
+          rdfs:range xsd:string .
+:maintainerId rdf:type owl:DatatypeProperty ;
+              rdfs:domain :Maintainer ;
+              rdfs:range xsd:string .
+:middleName rdf:type owl:DatatypeProperty ;
+            rdfs:domain :PersonOrPhysicalEntity ;
+            rdfs:range xsd:string .
+:mobileNumber rdf:type owl:DatatypeProperty ;
+              rdfs:domain :PersonOrPhysicalEntity ;
+              rdfs:range xsd:integer .
+:password rdf:type owl:DatatypeProperty ;
+          rdfs:domain [ rdf:type owl:Class ;
+                        owl:unionOf ( :Customer
+                                      :PasswordOfCustomer
+                                    )
+                      ] ;
+          rdfs:range xsd:string .
+:phoneNumber rdf:type owl:DatatypeProperty ;
+             rdfs:domain :PersonOrPhysicalEntity ;
+             rdfs:range xsd:integer .
+:powerSourceType rdf:type owl:DatatypeProperty ;
+                 rdfs:domain :PowerSource ;
+                 rdfs:range [ rdf:type rdfs:Datatype ;
+                              owl:oneOf [ rdf:type rdf:List ;
+                                          rdf:first "ac" ;
+                                          rdf:rest [ rdf:type rdf:List ;
+                                                     rdf:first "dc" ;
+                                                     rdf:rest rdf:nil
+                                                   ]
+                                        ]
+                            ] .
+:powerSourceVoltage rdf:type owl:DatatypeProperty ;
+                    rdfs:domain :PowerSource ;
+                    rdfs:range xsd:integer .
+:powerSupplySwitch rdf:type owl:DatatypeProperty ;
+                   rdfs:domain :PowerSupply ;
+                   rdfs:range [ rdf:type rdfs:Datatype ;
+                                owl:oneOf [ rdf:type rdf:List ;
+                                            rdf:first " manual " ;
+                                            rdf:rest rdf:nil
+                                          ]
+                              ] .
+:productID rdf:type owl:DatatypeProperty ;
+           rdfs:domain :Product ;
+           rdfs:range xsd:string .
+:productName rdf:type owl:DatatypeProperty ;
+             rdfs:domain :Product ;
+             rdfs:range xsd:string .
+:productType rdf:type owl:DatatypeProperty ;
+             rdfs:domain :Product ;
+             rdfs:range xsd:string .
+:productionDate rdf:type owl:DatatypeProperty ;
+                rdfs:domain :Product ;
+                rdfs:range xsd:dateTime .
+:readableBankCode rdf:type owl:DatatypeProperty ;
+                  rdfs:domain :ReadableBankCodeOfCashCard ;
+                  rdfs:range xsd:string .
+:recordValue rdf:type owl:DatatypeProperty ;
+             rdfs:domain :CardSerialNumberOfCashCard .
+:salary rdf:type owl:DatatypeProperty ;
+        rdfs:domain :Employee ;
+        rdfs:range xsd:float .
+:timeConstraint rdf:type owl:DatatypeProperty ;
+                rdfs:domain [ rdf:type owl:Class ;
+                              owl:unionOf ( :DisplayTime
+                                            :InteractionTime
+                                          )
+                            ] ;
+                rdfs:range [ rdf:type rdfs:Datatype ;
+                             owl:oneOf [ rdf:type rdf:List ;
+                                         rdf:first " is_less_than" ;
+                                         rdf:rest [ rdf:type rdf:List ;
+                                                    rdf:first "atleast" ;
+                                                    rdf:rest [ rdf:type rdf:List ;
+                                                               rdf:first "atmost" ;
+                                                               rdf:rest [ rdf:type rdf:List ;
+                                                                          rdf:first "is_greater_than" ;
+                                                                          rdf:rest rdf:nil
+                                                                        ]
+                                                             ]
+                                                  ]
+                                       ]
+                           ] .
+:tranacactionId rdf:type owl:DatatypeProperty ;
+                rdfs:domain :Transaction ;
+                rdfs:range xsd:string .
+:transactionAmount rdf:type owl:DatatypeProperty ;
+                   rdfs:domain [ rdf:type owl:Class ;
+                                 owl:unionOf ( :ATMTransaction
+                                               :TransactionAmountOfTransaction
+                                               :TransactionAmountOfTransactionCardSerialNumberOfCashCard
+                                               :TransactionAmountOfTransactionCardSerialNumberOfCashCardToBankComputer
+                                               :TransactionAmountOfTransactionFromATM
+                                               :TransactionAmountOfTransactionToBankComputer
+                                             )
+                               ] ;
+                   rdfs:range xsd:integer .
+:transactionTimestamp rdf:type owl:DatatypeProperty ;
+                      rdfs:domain :Transaction ;
+                      rdfs:range xsd:dateTimeStamp .
+:transactionType rdf:type owl:DatatypeProperty ;
+                 rdfs:domain :Transaction ;
+                 rdfs:range xsd:string .
+:transcactionDate rdf:type owl:DatatypeProperty ;
+                  rdfs:domain :Transaction ;
+                  rdfs:range xsd:dateTime .
+:transcactionStatus rdf:type owl:DatatypeProperty ;
+                    rdfs:domain :Transaction ;
+                    rdfs:range xsd:string .
+:typedpassword rdf:type owl:DatatypeProperty ;
+               rdfs:domain [ rdf:type owl:Class ;
+                             owl:unionOf ( :Customer
+                                           :TypedPasswordOfCustomer
+                                           :TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM
+                                           :TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer
+                                         )
+                           ] ;
+               rdfs:range xsd:string .
+:workload rdf:type owl:DatatypeProperty ;
+          rdfs:domain :Computer .
+:zipCode rdf:type owl:DatatypeProperty ;
+         rdfs:domain :PersonOrPhysicalEntity ;
+         rdfs:range xsd:integer .
+:ATM rdf:type owl:Class ;
+     rdfs:subClassOf :Service .
+:ATMStatus rdf:type owl:Class ;
+           rdfs:subClassOf :Status .
+:ATMTransaction rdf:type owl:Class ;
+                rdfs:subClassOf :Transaction .
+:ATMtotalFundOfATM rdf:type owl:Class .
+:AccessMethodProtocol rdf:type owl:Class ;
+                      rdfs:subClassOf :Protocol .
+:Account rdf:type owl:Class ;
+         rdfs:subClassOf :Product .
+:AccountBalanceOFAccount rdf:type owl:Class .
+:AccountCountFailPinOfAccount rdf:type owl:Class .
+:AccountMaxWithdrawalPerDayAndAccountOfAccount rdf:type owl:Class .
+:Angle_unit rdf:type owl:Class ;
+            rdfs:subClassOf :Unit .
+:Angstorm rdf:type owl:Class ;
+          rdfs:subClassOf :Length_Unit .
+:ApplicationSoftware rdf:type owl:Class ;
+                     rdfs:subClassOf :Software .
+:Audio rdf:type owl:Class ;
+       rdfs:subClassOf :Codec .
+:Authorization rdf:type owl:Class ;
+               rdfs:subClassOf :Process .
+:Bank rdf:type owl:Class ;
+      rdfs:subClassOf :Company .
+:BankCodeOfBank rdf:type owl:Class .
+:BankComputer rdf:type owl:Class ;
+              rdfs:subClassOf :Computer .
+:BankMaxWithdrawalPerTransactionOfBank rdf:type owl:Class .
+:BasicRequirement rdf:type owl:Class ;
+                  rdfs:subClassOf :Requirement .
+:Bit rdf:type owl:Class ;
+     rdfs:subClassOf :Information_unit .
+:BoilerPlateParts rdf:type owl:Class .
+:BusinessWorkflowSoftware rdf:type owl:Class ;
+                          rdfs:subClassOf :EnterpriseInfrastructureSoftware .
+:Byte rdf:type owl:Class ;
+      rdfs:subClassOf :Information_unit .
+:CDMA rdf:type owl:Class ;
+      rdfs:subClassOf :AccessMethodProtocol .
+:CSMA rdf:type owl:Class ;
+      rdfs:subClassOf :AccessMethodProtocol .
+:CabinetCover rdf:type owl:Class ;
+              rdfs:subClassOf :HardwareComponent .
+:Cable rdf:type owl:Class ;
+       rdfs:subClassOf :MaritimeLength .
+:Candela_per_square_meter rdf:type owl:Class ;
+                          rdfs:subClassOf :Luminance_Unit .
+:Card rdf:type owl:Class .
+:CardReader rdf:type owl:Class ;
+            rdfs:subClassOf :DataInput .
+:CardSerialNumberOfCashCard rdf:type owl:Class .
+:CashCard rdf:type owl:Class ;
+          rdfs:subClassOf :Card .
+:CashCardStatus rdf:type owl:Class ;
+                rdfs:subClassOf :Status .
+:CashVault rdf:type owl:Class ;
+           rdfs:subClassOf :HardwareComponent .
+:CentiMorgan rdf:type owl:Class ;
+             rdfs:subClassOf :Length_Unit .
+:CentiRay rdf:type owl:Class ;
+          rdfs:subClassOf :Length_Unit .
+:Centimeter rdf:type owl:Class ;
+            rdfs:subClassOf :Length_Unit .
+:Chain rdf:type owl:Class ;
+       rdfs:subClassOf :Length_Unit .
+:Chroma_sampling_unit rdf:type owl:Class ;
+                      rdfs:subClassOf :Image_resolution .
+:Codec rdf:type owl:Class ;
+       rdfs:subClassOf :InformationStandard .
+:Company rdf:type owl:Class ;
+         rdfs:subClassOf :Customer ,
+                         :LegalEntity .
+:ComplexRequirement rdf:type owl:Class ;
+                    rdfs:subClassOf :Requirement .
+:Computer rdf:type owl:Class .
+:ComputerProgrammingTools rdf:type owl:Class ;
+                          rdfs:subClassOf :Software .
+:Conditional rdf:type owl:Class ;
+             rdfs:subClassOf :BoilerPlateParts .
+:Cost rdf:type owl:Class ;
+      rdfs:subClassOf :PhysicalQuantity .
+:Count rdf:type owl:Class ;
+       rdfs:subClassOf :PhysicalQuantity .
+:CurrentAccount rdf:type owl:Class ;
+                rdfs:subClassOf :Account .
+:Customer rdf:type owl:Class ;
+          rdfs:subClassOf :PersonOrPhysicalEntity .
+:DataInput rdf:type owl:Class ;
+           rdfs:subClassOf :HardwareComponent .
+:DataTransferProtocol rdf:type owl:Class ;
+                      rdfs:subClassOf :Protocol .
+:DatabaseManagementSystem rdf:type owl:Class ;
+                          rdfs:subClassOf :EnterpriseInfrastructureSoftware .
+:Decibel rdf:type owl:Class ;
+         rdfs:subClassOf :Ratio .
+:Degree rdf:type owl:Class ;
+        rdfs:subClassOf :Plane_angle_unit .
+:Deposit rdf:type owl:Class ;
+         rdfs:subClassOf :ATMTransaction .
+:DialUp rdf:type owl:Class ;
+        rdfs:subClassOf :InternetAccess .
+:DigitalAssetManagement rdf:type owl:Class ;
+                        rdfs:subClassOf :EnterpriseInfrastructureSoftware .
+:Diomensionless_unit rdf:type owl:Class ;
+                     rdfs:subClassOf :Unit .
+:Display rdf:type owl:Class .
+:DisplayTime rdf:type owl:Class ;
+             rdfs:subClassOf :Time .
+:DotMatrixPrinter rdf:type owl:Class ;
+                  rdfs:subClassOf :Printer .
+:Dots_per_inch rdf:type owl:Class ;
+               rdfs:subClassOf :Spatial_resolution_unit .
+:Dynamic_range_unit rdf:type owl:Class ;
+                    rdfs:subClassOf :Image_resolution .
+:ElectricPotentialDifferenceUnit rdf:type owl:Class ;
+                                 rdfs:subClassOf :Unit .
+:Else rdf:type owl:Class ;
+      rdfs:subClassOf :BoilerPlateParts .
+:Employee rdf:type owl:Class ;
+          rdfs:subClassOf :PersonOrPhysicalEntity .
+:EncryptionStandard rdf:type owl:Class ;
+                    rdfs:subClassOf :InformationStandard .
+:EnterpriseInfrastructureSoftware rdf:type owl:Class ;
+                                  rdfs:subClassOf :ApplicationSoftware .
+:Entity rdf:type owl:Class .
+:ErrorDisplay rdf:type owl:Class ;
+              rdfs:subClassOf :Display .
+:FTP rdf:type owl:Class ;
+     rdfs:subClassOf :DataTransferProtocol .
+:Fathom rdf:type owl:Class ;
+        rdfs:subClassOf :MaritimeLength .
+:FiberGlass rdf:type owl:Class ;
+            rdfs:subClassOf :Material .
+:Foot rdf:type owl:Class ;
+      rdfs:subClassOf :Length_Unit .
+:Fraction rdf:type owl:Class ;
+          rdfs:subClassOf :Ratio .
+:Function rdf:type owl:Class .
+:FunctionalKey rdf:type owl:Class ;
+               rdfs:subClassOf :Keys .
+:Furlong rdf:type owl:Class ;
+         rdfs:subClassOf :Length_Unit .
+:Gigabyte rdf:type owl:Class ;
+          rdfs:subClassOf :Information_unit .
+:HardwareComponent rdf:type owl:Class .
+:Height rdf:type owl:Class ;
+        rdfs:subClassOf :Length .
+:IFBBThenBBElseBB rdf:type owl:Class ;
+                  rdfs:subClassOf :ComplexRequirement .
+:IfBBThenBB rdf:type owl:Class ;
+            rdfs:subClassOf :ComplexRequirement .
+:Image_resolution rdf:type owl:Class ;
+                  rdfs:subClassOf :Information_unit .
+:Inch rdf:type owl:Class ;
+      rdfs:subClassOf :Length_Unit .
+:InformationStandard rdf:type owl:Class .
+:Information_unit rdf:type owl:Class ;
+                  rdfs:subClassOf :Unit .
+:Interaction rdf:type owl:Class .
+:InteractionFromBankComputer rdf:type owl:Class .
+:InteractionTime rdf:type owl:Class ;
+                 rdfs:subClassOf :Time .
+:InteractionToATM rdf:type owl:Class .
+:InternetAccess rdf:type owl:Class .
+:Keypad rdf:type owl:Class ;
+        rdfs:subClassOf :DataInput .
+:Keys rdf:type owl:Class ;
+      rdfs:subClassOf :DataInput .
+:Kibibyte rdf:type owl:Class ;
+          rdfs:subClassOf :Information_unit .
+:Kilobyte rdf:type owl:Class ;
+          rdfs:subClassOf :Information_unit .
+:League rdf:type owl:Class ;
+        rdfs:subClassOf :Length_Unit .
+:LegalEntity rdf:type owl:Class ;
+             rdfs:subClassOf :Entity .
+:Length rdf:type owl:Class ;
+        rdfs:subClassOf :PhysicalQuantity .
+:Length_Unit rdf:type owl:Class ;
+             rdfs:subClassOf :Unit .
+:Light_Unit rdf:type owl:Class ;
+            rdfs:subClassOf :Unit .
+:LockingSystem rdf:type owl:Class ;
+               rdfs:subClassOf :HardwareComponent .
+:Luminance_Unit rdf:type owl:Class ;
+                rdfs:subClassOf :Light_Unit .
+:MagneticCardReader rdf:type owl:Class ;
+                    rdfs:subClassOf :CardReader .
+:Maintainer rdf:type owl:Class ;
+            rdfs:subClassOf :Employee ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :maintains ;
+                              owl:someValuesFrom :ATM
+                            ] .
+:MaritimeLength rdf:type owl:Class ;
+                rdfs:subClassOf :Length_Unit .
+:Material rdf:type owl:Class ;
+          rdfs:subClassOf :Resource .
+:Mebibyte rdf:type owl:Class ;
+          rdfs:subClassOf :Information_unit .
+:Megabyte rdf:type owl:Class ;
+          rdfs:subClassOf :Information_unit .
+:Memory rdf:type owl:Class ;
+        rdfs:subClassOf :HardwareComponent .
+:Micrometer rdf:type owl:Class ;
+            rdfs:subClassOf :Length_Unit .
+:Micron_pixel rdf:type owl:Class ;
+              rdfs:subClassOf :Spatial_resolution_unit .
+:Mile rdf:type owl:Class ;
+      rdfs:subClassOf :Length_Unit .
+:MilliMeter rdf:type owl:Class ;
+            rdfs:subClassOf :Length_Unit .
+:Mole_fraction rdf:type owl:Class ;
+               rdfs:subClassOf :Fraction .
+:Money rdf:type owl:Class ;
+       rdfs:subClassOf :Cost .
+:MoneyUnit rdf:type owl:Class ;
+           rdfs:subClassOf :Unit .
+:NanoMeter rdf:type owl:Class ;
+           rdfs:subClassOf :Length_Unit .
+:NauticalMile rdf:type owl:Class ;
+              rdfs:subClassOf :MaritimeLength .
+:Negative rdf:type owl:Class ;
+          rdfs:subClassOf :Response .
+:NetworkSuites rdf:type owl:Class .
+:NonVotalite rdf:type owl:Class ;
+             rdfs:subClassOf :Memory .
+:NormalDisplay rdf:type owl:Class ;
+               rdfs:subClassOf :Display .
+:OSI rdf:type owl:Class ;
+     rdfs:subClassOf :NetworkSuites .
+:Object rdf:type owl:Class ;
+        rdfs:subClassOf :BoilerPlateParts .
+:OfEntity rdf:type owl:Class ;
+          rdfs:subClassOf :BoilerPlateParts .
+:PasswordOfCustomer rdf:type owl:Class .
+:Percent rdf:type owl:Class ;
+         rdfs:subClassOf :Ratio .
+:PersonOrPhysicalEntity rdf:type owl:Class ;
+                        rdfs:subClassOf :Entity .
+:PhysicalQuantity rdf:type owl:Class .
+:PicoMeter rdf:type owl:Class ;
+           rdfs:subClassOf :Length_Unit .
+:Pixels_per_inch rdf:type owl:Class ;
+                 rdfs:subClassOf :Spatial_resolution_unit .
+:Pixels_per_millimeter rdf:type owl:Class ;
+                       rdfs:subClassOf :Spatial_resolution_unit .
+:Plane_angle_unit rdf:type owl:Class ;
+                  rdfs:subClassOf :Angle_unit .
+:Positive rdf:type owl:Class ;
+          rdfs:subClassOf :Response .
+:PowerSource rdf:type owl:Class ;
+             rdfs:subClassOf :Resource .
+:PowerSupply rdf:type owl:Class ;
+             rdfs:subClassOf :HardwareComponent .
+:Power_unit rdf:type owl:Class ;
+            rdfs:subClassOf :Unit .
+:Printer rdf:type owl:Class ;
+         rdfs:subClassOf :HardwareComponent .
+:Process rdf:type owl:Class .
+:ProcessStatus rdf:type owl:Class ;
+               rdfs:subClassOf :Status .
+:ProcessSuccessfulStatus rdf:type owl:Class ;
+                         rdfs:subClassOf :ProcessStatus .
+:ProcessUnwantedStatus rdf:type owl:Class ;
+                       rdfs:subClassOf :ProcessStatus .
+:Product rdf:type owl:Class .
+:Protocol rdf:type owl:Class .
+:QualitativeCost rdf:type owl:Class ;
+                 rdfs:subClassOf :Cost .
+:Radian rdf:type owl:Class ;
+        rdfs:subClassOf :Plane_angle_unit .
+:Ratio rdf:type owl:Class ;
+       rdfs:subClassOf :Diomensionless_unit ,
+                       :Percent .
+:ReadableBankCodeOfCashCard rdf:type owl:Class .
+:Receipt rdf:type owl:Class .
+:Request rdf:type owl:Class ;
+         rdfs:subClassOf :Interaction .
+:Requirement rdf:type owl:Class .
+:Resource rdf:type owl:Class .
+:Response rdf:type owl:Class ;
+          rdfs:subClassOf :Interaction .
+:ResponseFromBankComputer rdf:type owl:Class .
+:SavingAccount rdf:type owl:Class ;
+               rdfs:subClassOf :Account .
+:Screen rdf:type owl:Class ;
+        rdfs:subClassOf :HardwareComponent .
+:SecurityCamera rdf:type owl:Class ;
+                rdfs:subClassOf :HardwareComponent .
+:SecurityStandard rdf:type owl:Class ;
+                  rdfs:subClassOf :InformationStandard .
+:Server rdf:type owl:Class ;
+        rdfs:subClassOf :Computer .
+:ServerWorkLoad rdf:type owl:Class ;
+                rdfs:subClassOf :WorkLoad .
+:Service rdf:type owl:Class .
+:SmartCardReader rdf:type owl:Class ;
+                 rdfs:subClassOf :CardReader .
+:Software rdf:type owl:Class .
+:Solid_angle_unit rdf:type owl:Class ;
+                  rdfs:subClassOf :Angle_unit .
+:Spatial_resolution_unit rdf:type owl:Class ;
+                         rdfs:subClassOf :Image_resolution .
+:Speaker rdf:type owl:Class ;
+         rdfs:subClassOf :HardwareComponent .
+:Status rdf:type owl:Class .
+:StatusInteractionFromBankComputer rdf:type owl:Class .
+:StatusInteractionToATM rdf:type owl:Class .
+:StatusPowerSupplyStatus rdf:type owl:Class ;
+                         rdfs:subClassOf :Status .
+:Steredian rdf:type owl:Class ;
+           rdfs:subClassOf :Solid_angle_unit .
+:Subject rdf:type owl:Class ;
+         rdfs:subClassOf :BoilerPlateParts .
+:SubjectVerbObject rdf:type owl:Class ;
+                   rdfs:subClassOf :BasicRequirement .
+:SubjectVerbObjectOfEntity rdf:type owl:Class ;
+                           rdfs:subClassOf :BasicRequirement .
+:SuccessfulSates rdf:type owl:Class ;
+                 rdfs:subClassOf :CashCardStatus .
+:SystemSoftware rdf:type owl:Class ;
+                rdfs:subClassOf :Software .
+:TFTP rdf:type owl:Class ;
+      rdfs:subClassOf :FTP .
+:Terabyte rdf:type owl:Class ;
+          rdfs:subClassOf :Information_unit .
+:Text rdf:type owl:Class ;
+      rdfs:subClassOf :Codec .
+:Thickness rdf:type owl:Class ;
+           rdfs:subClassOf :Length .
+:Thou rdf:type owl:Class ;
+      rdfs:subClassOf :Length_Unit .
+:Time rdf:type owl:Class ;
+      rdfs:subClassOf :PhysicalQuantity .
+:TimeUnit rdf:type owl:Class ;
+          rdfs:subClassOf :Unit .
+:ToEntity rdf:type owl:Class ;
+          rdfs:subClassOf :BoilerPlateParts .
+:Transaction rdf:type owl:Class .
+:TransactionAmountOfTransaction rdf:type owl:Class .
+:TransactionAmountOfTransactionCardSerialNumberOfCashCard rdf:type owl:Class .
+:TransactionAmountOfTransactionCardSerialNumberOfCashCardToBankComputer rdf:type owl:Class .
+:TransactionAmountOfTransactionFromATM rdf:type owl:Class .
+:TransactionAmountOfTransactionToBankComputer rdf:type owl:Class .
+:TransactionByBank rdf:type owl:Class ;
+                   rdfs:subClassOf :Transaction .
+:TransactionDialog rdf:type owl:Class ;
+                   rdfs:subClassOf :Process .
+:Transfer rdf:type owl:Class ;
+          rdfs:subClassOf :ATMTransaction .
+:Transmission rdf:type owl:Class ;
+              rdfs:subClassOf :Function .
+:TypedPasswordOfCustomer rdf:type owl:Class .
+:TypedPasswordOfCustomerCardSerialNumberOfCashCardFromATM rdf:type owl:Class .
+:TypedPasswordOfCustomerCardSerialNumberOfCashCardToBanKComputer rdf:type owl:Class .
+:TypedPasswordOfCustomerToBankComputer rdf:type owl:Class .
+:UnWantedStates rdf:type owl:Class ;
+                rdfs:subClassOf :CashCardStatus .
+:Unit rdf:type owl:Class .
+:UnwantedATMStatus rdf:type owl:Class ;
+                   rdfs:subClassOf :ATMStatus .
+:UnwantedPowerSupplyStatus rdf:type owl:Class ;
+                           rdfs:subClassOf :StatusPowerSupplyStatus .
+:Validation rdf:type owl:Class ;
+            rdfs:subClassOf :Process .
+:Verb rdf:type owl:Class ;
+      rdfs:subClassOf :BoilerPlateParts .
+:Verification rdf:type owl:Class ;
+              rdfs:subClassOf :Function .
+:Video rdf:type owl:Class ;
+       rdfs:subClassOf :Codec .
+:Volalite rdf:type owl:Class ;
+          rdfs:subClassOf :Memory .
+:WantedATMStatus rdf:type owl:Class ;
+                 rdfs:subClassOf :ATMStatus .
+:Watt rdf:type owl:Class ;
+      rdfs:subClassOf :Power_unit .
+:WebTransaction rdf:type owl:Class ;
+                rdfs:subClassOf :Transaction .
+:Width rdf:type owl:Class ;
+       rdfs:subClassOf :Length .
+:Withdrawal rdf:type owl:Class ;
+            rdfs:subClassOf :ATMTransaction .
+:WorkLoad rdf:type owl:Class ;
+          rdfs:subClassOf :PhysicalQuantity .
+:Yard rdf:type owl:Class ;
+      rdfs:subClassOf :Length_Unit .
+:meter rdf:type owl:Class ;
+       rdfs:subClassOf :Length_Unit .
+<http://lod.csd.auth.gr/atm/atm.ttl#TCP/IP> rdf:type owl:Class ;
+                                            rdfs:subClassOf :NetworkSuites .
+:ATM rdf:type owl:NamedIndividual ,
+              :Object ,
+              :Subject ,
+              :ToEntity .
+:ATMCardService rdf:type owl:NamedIndividual ,
+                         :Verification .
+:ATM_returns_Cashcard rdf:type owl:NamedIndividual ,
+                               :SubjectVerbObject ;
+                      :object :CashCard ;
+                      :subject :ATM ;
+                      :verb :returns .
+:AbNormalShutDown rdf:type owl:NamedIndividual ,
+                           :UnwantedATMStatus .
+:AcceptAuthorization rdf:type owl:NamedIndividual ,
+                              :Object ,
+                              :Positive .
+:AmountIsGreaterM rdf:type owl:NamedIndividual ,
+                           :Negative .
+:AmountIsLessN rdf:type owl:NamedIndividual ,
+                        :Negative .
+:AmountIsNotAccept_m rdf:type owl:NamedIndividual ,
+                              :ErrorDisplay .
+:AmountIsNotAccept_n rdf:type owl:NamedIndividual ,
+                              :ErrorDisplay .
+:AmountIsUpdated rdf:type owl:NamedIndividual ,
+                          :Positive .
+:AuthorizationRequest rdf:type owl:NamedIndividual ,
+                               :Request .
+:BMSVersion2.0 rdf:type owl:NamedIndividual ,
+                        :BusinessWorkflowSoftware .
+:BankComputer rdf:type owl:NamedIndividual ,
+                       :Subject .
+:BankComputer_records_cardSerialnumber_of_CashCard rdf:type owl:NamedIndividual ,
+                                                            :SubjectVerbObjectOfEntity ;
+                                                   :object :cardSerialNumber ;
+                                                   :ofEntity :CashCard ;
+                                                   :subject :BankComputer ;
+                                                   :verb :records .
+:CardisKept rdf:type owl:NamedIndividual ,
+                     :UnWantedStates .
+:CashCard rdf:type owl:NamedIndividual ,
+                   :Object ,
+                   :OfEntity ,
+                   :Subject .
+:Century rdf:type owl:NamedIndividual ,
+                  :TimeUnit .
+:ChoiseOfTranscaction rdf:type owl:NamedIndividual ,
+                               :NormalDisplay .
+:Combination rdf:type owl:NamedIndividual ,
+                      :LockingSystem .
+:Customer rdf:type owl:NamedIndividual ,
+                   :OfEntity .
+:Day rdf:type owl:NamedIndividual ,
+              :TimeUnit .
+:DisplayBalanceReceiptOrScreen rdf:type owl:NamedIndividual ,
+                                        :NormalDisplay .
+:Dollars rdf:type owl:NamedIndividual ,
+                  :MoneyUnit .
+:Else_CashCard_is_in_state_StatusValidPassword rdf:type owl:NamedIndividual ,
+                                                        :Else ;
+                                               :object :AcceptAuthorization ,
+                                                       :StatusValidCashCard ,
+                                                       :StatusValidPassword ;
+                                               :subject :BankComputer ,
+                                                        :CashCard ;
+                                               :toEntity :ATM ;
+                                               :verb :is_in_state ,
+                                                     :sends .
+:ErrorMessageforAtLeast30Sec rdf:type owl:NamedIndividual ,
+                                      :ErrorDisplay .
+:Euro rdf:type owl:NamedIndividual ,
+               :MoneyUnit .
+:ExpireState rdf:type owl:NamedIndividual ,
+                      :UnWantedStates .
+:FinishedState rdf:type owl:NamedIndividual ,
+                        :ProcessSuccessfulStatus .
+:HalfLife rdf:type owl:NamedIndividual ,
+                   :TimeUnit .
+:Heavy rdf:type owl:NamedIndividual ,
+                :Server .
+:Hour rdf:type owl:NamedIndividual ,
+               :TimeUnit .
+:If__typedpassword_of_Customer_not_equals_password_of__Customer_then_CashCard_is_in_state_StatusBadPassword_Else_CashCard_is_in_state_StatusValidPassword rdf:type owl:NamedIndividual ,
+                                                                                                                                                                   :IFBBThenBBElseBB ;
+                                                                                                                                                          :condition :If_typedpassword_of_Customer_not_equals_password_of_Customer ;
+                                                                                                                                                          :else :Else_CashCard_is_in_state_StatusValidPassword ;
+                                                                                                                                                          :object :StatusInValidCashCard ,
+                                                                                                                                                                  :rejectionAuthorization ,
+                                                                                                                                                                  :statusBadPassword ;
+                                                                                                                                                          :subject :BankComputer ,
+                                                                                                                                                                   :CashCard ;
+                                                                                                                                                          :toEntity :ATM ;
+                                                                                                                                                          :verb :is_in_state ,
+                                                                                                                                                                :sends .
+:If_typedpassword_of_Customer_not_equals_password_of_Customer rdf:type owl:NamedIndividual ,
+                                                                       :Conditional ;
+                                                              :object :password ;
+                                                              :ofEntity :Customer ;
+                                                              :subject :typedPassword ;
+                                                              :verb :not_equals .
+:InValidCashcard rdf:type owl:NamedIndividual ,
+                          :ErrorDisplay .
+:InitialDisplay rdf:type owl:NamedIndividual ,
+                         :NormalDisplay ,
+                         :Object .
+:InitialWithdrawalSequence rdf:type owl:NamedIndividual ,
+                                    :Display .
+:MicroSecond rdf:type owl:NamedIndividual ,
+                      :TimeUnit .
+:MilliSecond rdf:type owl:NamedIndividual ,
+                      :TimeUnit .
+:Minute rdf:type owl:NamedIndividual ,
+                 :TimeUnit .
+:Month rdf:type owl:NamedIndividual ,
+                :TimeUnit .
+:NanoSecond rdf:type owl:NamedIndividual ,
+                     :TimeUnit .
+:No_Money rdf:type owl:NamedIndividual ,
+                   :UnwantedATMStatus .
+:Normal rdf:type owl:NamedIndividual ,
+                 :Server .
+:NotFinishedState rdf:type owl:NamedIndividual ,
+                           :ProcessUnwantedStatus .
+:OracleVersion7.0 rdf:type owl:NamedIndividual ,
+                           :DatabaseManagementSystem .
+:PicoSecond rdf:type owl:NamedIndividual ,
+                     :TimeUnit .
+:Pin rdf:type owl:NamedIndividual ,
+              :Verification .
+:PinTransmission rdf:type owl:NamedIndividual ,
+                          :Transmission .
+:PowerFailures rdf:type owl:NamedIndividual ,
+                        :UnwantedPowerSupplyStatus .
+:Restart rdf:type owl:NamedIndividual ,
+                  :WantedATMStatus .
+:Second rdf:type owl:NamedIndividual ,
+                 :TimeUnit .
+:ShutDown rdf:type owl:NamedIndividual ,
+                   :WantedATMStatus .
+:StartState rdf:type owl:NamedIndividual ,
+                     :ProcessSuccessfulStatus .
+:StatusInValidCashCard rdf:type owl:NamedIndividual ,
+                                :Object ,
+                                :UnWantedStates .
+:StatusValidAccount rdf:type owl:NamedIndividual ,
+                             :SuccessfulSates .
+:StatusValidBankCode rdf:type owl:NamedIndividual ,
+                              :SuccessfulSates .
+:StatusValidCashCard rdf:type owl:NamedIndividual ,
+                              :Object ,
+                              :SuccessfulSates .
+:StatusValidPassword rdf:type owl:NamedIndividual ,
+                              :Object ,
+                              :SuccessfulSates .
+:StatusValidSerialNumber rdf:type owl:NamedIndividual ,
+                                  :SuccessfulSates .
+:TransactionNotSucceeded rdf:type owl:NamedIndividual ,
+                                  :Negative .
+:TransactionSucceeded rdf:type owl:NamedIndividual ,
+                               :Positive .
+:TranscactionAmount rdf:type owl:NamedIndividual ,
+                             :Request .
+:TripleDes rdf:type owl:NamedIndividual ,
+                    :EncryptionStandard .
+:ValidCashCard rdf:type owl:NamedIndividual ,
+                        :Positive .
+:Volt rdf:type owl:NamedIndividual ,
+               :ElectricPotentialDifferenceUnit .
+:Week rdf:type owl:NamedIndividual ,
+               :TimeUnit .
+:WrongAccount rdf:type owl:NamedIndividual ,
+                       :ErrorDisplay .
+:WrongBankCode rdf:type owl:NamedIndividual ,
+                        :ErrorDisplay .
+:WrongPassword rdf:type owl:NamedIndividual ,
+                        :ErrorDisplay .
+:Yamaha rdf:type owl:NamedIndividual ,
+                 :Audio .
+:Year rdf:type owl:NamedIndividual ,
+               :TimeUnit .
+:badAccount rdf:type owl:NamedIndividual ,
+                     :Negative .
+:badBankcode rdf:type owl:NamedIndividual ,
+                      :Negative .
+:badPassword rdf:type owl:NamedIndividual ,
+                      :Negative .
+:cardSerialNumber rdf:type owl:NamedIndividual ,
+                           :Object .
+:displays rdf:type owl:NamedIndividual ,
+                   :Verb .
+:has_no_money rdf:type owl:NamedIndividual ,
+                       :ErrorDisplay .
+:if_CashCard_is_in_not_ATM rdf:type owl:NamedIndividual ,
+                                    :Conditional ;
+                           :object :ATM ;
+                           :subject :CashCard ;
+                           :verb :is_in_not .
+:if_CashCard_is_in_not_ATM_then_ATM_displays_Initial_Display rdf:type owl:NamedIndividual ,
+                                                                      :IfBBThenBB ;
+                                                             :condition :if_CashCard_is_in_not_ATM ;
+                                                             :object :InitialDisplay ;
+                                                             :subject :ATM ;
+                                                             :verb :displays .
+:invalidCashard rdf:type owl:NamedIndividual ,
+                         :Negative .
+:is_in_not rdf:type owl:NamedIndividual ,
+                    :Verb .
+:is_in_state rdf:type owl:NamedIndividual ,
+                      :Verb .
+:not_equals rdf:type owl:NamedIndividual ,
+                     :Verb .
+:password rdf:type owl:NamedIndividual ,
+                   :Object .
+:records rdf:type owl:NamedIndividual ,
+                  :Verb ;
+         :object :cardSerialNumber ;
+         :ofEntity :CashCard ;
+         :subject :BankComputer ;
+         :verb :records .
+:rejectionAuthorization rdf:type owl:NamedIndividual ,
+                                 :Negative ,
+                                 :Object .
+:returns rdf:type owl:NamedIndividual ,
+                  :Verb .
+:sends rdf:type owl:NamedIndividual ,
+                :Verb .
+:statusBadAccount rdf:type owl:NamedIndividual ,
+                           :UnWantedStates .
+:statusBadBankCode rdf:type owl:NamedIndividual ,
+                            :UnWantedStates .
+:statusBadPassword rdf:type owl:NamedIndividual ,
+                            :Object ,
+                            :UnWantedStates .
+:three rdf:type owl:NamedIndividual ,
+                :Count .
+:typedPassword rdf:type owl:NamedIndividual ,
+                        :Subject .

--- a/evaluation/atm_gold1.ttl
+++ b/evaluation/atm_gold1.ttl
@@ -1,0 +1,58 @@
+@prefix atm: <http://lod.csd.auth.gr/atm/atm.ttl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Class hierarchy
+atm:Withdrawal rdfs:subClassOf atm:ATMTransaction .
+
+# Object properties
+atm:belongsToBank a owl:ObjectProperty ;
+  rdfs:domain atm:ATM ;
+  rdfs:range atm:Bank .
+
+atm:hasCashCard a owl:ObjectProperty ;
+  rdfs:domain atm:Customer ;
+  rdfs:range atm:CashCard .
+
+atm:holds a owl:ObjectProperty ;
+  rdfs:domain atm:Customer ;
+  rdfs:range atm:Account .
+
+atm:involves a owl:ObjectProperty ;
+  rdfs:domain atm:CashCard ;
+  rdfs:range atm:Account .
+
+atm:accepts a owl:ObjectProperty ;
+  rdfs:domain atm:ATM ;
+  rdfs:range atm:CashCard .
+
+atm:isLinkedToATM a owl:ObjectProperty ;
+  rdfs:domain atm:ATMTransaction ;
+  rdfs:range atm:ATM .
+
+atm:isLinkedTo a owl:ObjectProperty ;
+  rdfs:domain atm:ATMTransaction ;
+  rdfs:range atm:Account .
+
+# Example individuals
+atm:bank1 a atm:Bank .
+
+atm:atm1 a atm:ATM ;
+  atm:belongsToBank atm:bank1 ;
+  atm:accepts atm:card1 .
+
+atm:customer1 a atm:Customer ;
+  atm:hasCashCard atm:card1 ;
+  atm:holds atm:account1 .
+
+atm:card1 a atm:CashCard ;
+  atm:involves atm:account1 .
+
+atm:account1 a atm:Account .
+
+atm:withdrawal1 a atm:Withdrawal ;
+  atm:isLinkedToATM atm:atm1 ;
+  atm:isLinkedTo atm:account1 .
+


### PR DESCRIPTION
## Summary
- Introduce `atm_gold1.ttl` with a reduced set of ATM ontology classes and properties for streamlined evaluation.

## Testing
- `pytest tests/test_loader.py`
- `pytest tests/test_validator.py::test_validation_conforming`


------
https://chatgpt.com/codex/tasks/task_e_68b19f0b175483309190758ff78e279e