### PR TITLE
Handle invalid Turtle gracefully

### DIFF
--- a/ontology_guided/llm_interface.py
+++ b/ontology_guided/llm_interface.py
@@ -22,6 +22,7 @@ KNOWN_PREFIXES = {
     "schema": "http://schema.org/",
     "skos": "http://www.w3.org/2004/02/skos/core#",
     "foaf": "http://xmlns.com/foaf/0.1/",
+    "lex": "http://example.com/lexical#",
 }
 
 class LLMInterface:
@@ -221,9 +222,11 @@ class LLMInterface:
                     self.logger.warning("Invalid Turtle returned: %s", e)
                     if attempts > max_retries:
                         self.logger.error(
-                            "Failed to produce valid Turtle after %d retries", max_retries
+                            "Failed to produce valid Turtle after %d retries, returning empty output",
+                            max_retries,
                         )
-                        raise ValueError("LLM returned invalid Turtle") from e
+                        turtle_code = ""
+                        break
                     prompt = (
                         "Previous output was invalid Turtle; return only correct Turtle.\n"
                         + base_prompt
@@ -354,9 +357,11 @@ class LLMInterface:
                     self.logger.warning("Invalid Turtle returned: %s", e)
                     if attempts > max_retries:
                         self.logger.error(
-                            "Failed to produce valid Turtle after %d retries", max_retries
+                            "Failed to produce valid Turtle after %d retries, returning empty output",
+                            max_retries,
                         )
-                        raise ValueError("LLM returned invalid Turtle") from e
+                        turtle_code = ""
+                        break
                     prompt = (
                         "Previous output was invalid Turtle; return only correct Turtle.\n"
                         + base_prompt

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -225,7 +225,7 @@ def test_generate_owl_retry_on_invalid_turtle(monkeypatch, tmp_path):
     assert "Previous output was invalid Turtle" in prompts[1]
 
 
-def test_generate_owl_raises_after_invalid_turtle(monkeypatch, tmp_path):
+def test_generate_owl_returns_empty_after_invalid_turtle(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
     class FakeMessage:
@@ -247,8 +247,8 @@ def test_generate_owl_raises_after_invalid_turtle(monkeypatch, tmp_path):
     monkeypatch.setattr(time, "sleep", lambda *args, **kwargs: None)
 
     llm = LLMInterface(api_key="dummy", model="gpt-4", cache_dir=str(tmp_path))
-    with pytest.raises(ValueError):
-        llm.generate_owl(["irrelevant"], "{sentence}", max_retries=1, retry_delay=0)
+    result = llm.generate_owl(["irrelevant"], "{sentence}", max_retries=1, retry_delay=0)
+    assert result == [""]
 
 
 def test_generate_owl_passes_temperature_and_examples(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `lex` to auto-known prefixes for LLM snippets
- return empty Turtle instead of raising after repeated invalid outputs
- adjust tests for new behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a62245fc83308cd5c323c8beb2c8