### PR TITLE
Default missing efficiency metrics to zero

### DIFF
--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -210,12 +210,12 @@ def run_evaluations(
                 "prompts_per_iteration": (
                     efficiency.avg_prompts_per_iteration
                     if efficiency.avg_prompts_per_iteration is not None
-                    else ""
+                    else 0.0
                 ),
                 "prompt_success_rate": (
                     efficiency.success_rate_per_prompt
                     if efficiency.success_rate_per_prompt is not None
-                    else ""
+                    else 0.0
                 ),
                 "shacl_conforms_rate": (
                     sum(1 for c in conforms_list if c) / len(conforms_list)
@@ -223,7 +223,7 @@ def run_evaluations(
                     else 0.0
                 ),
                 "runs": repeats,
-                "cq_pass_rate": mean(cq_list) if cq_list else "",
+                "cq_pass_rate": mean(cq_list) if cq_list else 0.0,
             }
             table_rows.append(row)
 


### PR DESCRIPTION
## Summary
- Default repair efficiency metrics in `run_benchmark` to 0.0 when data is missing
- Ensure CQ pass rate falls back to 0.0 for empty results

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1afae56288330b68cd5ec4b8c719c