### PR TITLE
Add base and ontology declarations for Protégé compatibility

### DIFF
--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -28,6 +28,8 @@ class OntologyBuilder:
         self.lexical_namespace = lexical_namespace
         self.graph = Graph()
         self.graph.bind(self.prefix, self.base_iri)
+        ontology_iri = URIRef(self.base_iri.rstrip("#"))
+        self.graph.add((ontology_iri, RDF.type, OWL.Ontology))
         if ontology_files:
             for path in ontology_files:
                 self.graph.parse(path)
@@ -47,9 +49,9 @@ class OntologyBuilder:
         for prefix, uri in self.graph.namespaces():
             if prefix and prefix not in prefixes:
                 prefixes[prefix] = str(uri)
-        self.header = "".join(
-            f"@prefix {p}: <{u}> .\n" for p, u in prefixes.items()
-        )
+        header_lines = [f"@base <{self.base_iri}> .\n"]
+        header_lines += [f"@prefix {p}: <{u}> .\n" for p, u in prefixes.items()]
+        self.header = "".join(header_lines)
 
     def _extract_available_terms(self):
         nm = self.graph.namespace_manager
@@ -190,7 +192,7 @@ class OntologyBuilder:
 
     def save(self, file_path: str, fmt: str = "turtle"):
         """Αποθηκεύει την οντολογία σε αρχείο."""
-        self.graph.serialize(destination=file_path, format=fmt)
+        self.graph.serialize(destination=file_path, format=fmt, base=self.base_iri)
 
 
 if __name__ == "__main__":

--- a/tests/test_ontology_builder.py
+++ b/tests/test_ontology_builder.py
@@ -10,9 +10,10 @@ def test_parse_turtle_with_prefix():
     ob = OntologyBuilder('http://example.com/atm#')
     ttl = """@prefix ex: <http://example.com/> .\nex:A ex:B ex:C ."""
     logger = logging.getLogger(__name__)
+    initial_len = len(ob.graph)
     triples = ob.parse_turtle(ttl, logger=logger)
     ob.add_provenance("req", triples)
-    assert len(ob.graph) == 1
+    assert len(ob.graph) == initial_len + 1
     assert ob.triple_provenance
 
 
@@ -126,3 +127,12 @@ def test_parse_turtle_applies_synonym():
     assert (ex_fast, lex_antonym, ex_fast) in ob.graph
     assert (ex_quick, lex_antonym, ex_quick) not in ob.graph
     assert triples == [(ex_fast, lex_antonym, ex_fast)]
+
+
+def test_save_includes_base_and_ontology(tmp_path):
+    ob = OntologyBuilder('http://example.com/atm#')
+    out = tmp_path / 'out.ttl'
+    ob.save(out, fmt='turtle')
+    content = out.read_text(encoding='utf-8')
+    assert '@base <http://example.com/atm#> .' in content
+    assert '<http://example.com/atm> a owl:Ontology .' in content


### PR DESCRIPTION
## Summary
- Declare ontology IRI and `@base` when constructing graphs
- Pass base IRI to serializer to emit `@base` and ontology triple in outputs
- Test saved Turtle for base and ontology declaration

## Testing
- `pytest tests/test_ontology_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5553866588330864140f467e19487