### PR TITLE
Ensure Turtle output has blank line after @base for Protege compatibility

### DIFF
--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -235,6 +235,7 @@ class OntologyBuilder:
                 for line in self.prefix_lines:
                     fh.write(line)
                 fh.write(self.base_line)
+                fh.write("\n")
                 fh.write(f"<{ontology_iri}> rdf:type owl:Ontology .\n")
                 for line in body_lines:
                     fh.write(line + "\n")

--- a/results/combined.ttl
+++ b/results/combined.ttl
@@ -11,6 +11,7 @@
 @prefix lex: <http://example.com/lexical#> .
 @prefix ex: <http://example.com/lexical/example#> .
 @base <http://lod.csd.auth.gr/atm/atm.ttl#> .
+
 <http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .
 lex:Noun a rdfs:Class ;
     rdfs:subClassOf lex:Word .

--- a/tests/test_header_structure.py
+++ b/tests/test_header_structure.py
@@ -23,11 +23,12 @@ def test_header_and_ontology_elements(tmp_path):
         '@prefix swrlb: <http://www.w3.org/2003/11/swrlb#> .',
         '@prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .',
         '@base <http://lod.csd.auth.gr/atm/atm.ttl#> .',
+        '',
         '<http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .',
     ]
     assert ttl_lines[: len(expected_header)] == expected_header
 
-    non_prefix = [line for line in ttl_lines if not line.startswith('@')]
+    non_prefix = [line for line in ttl_lines if line and not line.startswith('@')]
     assert non_prefix[0] == '<http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .'
 
     import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary
- Ensure OntologyBuilder writes a blank line after the `@base` directive
- Adjust tests and sample `combined.ttl` to include the blank line

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba9bc0353883309e743e7e1057731c