### PR TITLE
style: reformat combined ontology for protege

### DIFF
--- a/results/combined.ttl
+++ b/results/combined.ttl
@@ -13,680 +13,867 @@
 @base <http://lod.csd.auth.gr/atm/atm.ttl#> .
 
 <http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .
-lex:Noun a rdfs:Class ;
+
+lex:Noun rdf:type rdfs:Class ;
     rdfs:subClassOf lex:Word .
-lex:Word a rdfs:Class .
-:AuthorizationProcess a rdfs:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+lex:Word rdf:type rdfs:Class .
+
+:AuthorizationProcess rdf:type rdfs:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :receivesAcceptanceFrom ;
             owl:someValuesFrom :BankComputer ] .
-:Bank a rdfs:Class,
+
+:Bank rdf:type rdfs:Class,
         owl:Class ;
     rdfs:label "Bank"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasBankCode ;
             owl:someValuesFrom :CashCard ] ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :providesSecurity ;
             owl:someValuesFrom :Computer ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :providesSecurity ;
             owl:someValuesFrom :Software ] .
-:Customer a rdfs:Class,
+
+:Customer rdf:type rdfs:Class,
         owl:Class ;
     rdfs:label "Customer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :callBank ;
             owl:someValuesFrom :Bank ] .
-:Message a rdfs:Class,
+
+:Message rdf:type rdfs:Class,
         owl:Class ;
     rdfs:label "Message"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :displayMessage ;
             owl:someValuesFrom :Bank ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :hasMessage ;
-            owl:someValuesFrom [ a owl:Class ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
                     owl:intersectionOf ( :ValidCashCard :ValidPassword :ProblemWithAccount ) ] ] .
-:StartTransactionDialog a rdfs:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:StartTransactionDialog rdf:type rdfs:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isStartedBy ;
-            owl:someValuesFrom [ a owl:Class ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
                     owl:intersectionOf ( :AuthorizationProcess :ValidPassword :ValidSerialNumber ) ] ] .
-:ValidPassword a rdfs:Class,
+
+:ValidPassword rdf:type rdfs:Class,
         owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasPassword ;
             owl:someValuesFrom :Password ],
         :Password .
-:ValidSerialNumber a rdfs:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:ValidSerialNumber rdf:type rdfs:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasSerialNumber ;
             owl:someValuesFrom :SerialNumber ] .
-lex:AccountHolder a lex:Word ;
+
+lex:AccountHolder rdf:type lex:Word ;
     lex:synonym :Customer .
-lex:AutomatedTellerMachine a lex:Word ;
+
+lex:AutomatedTellerMachine rdf:type lex:Word ;
     lex:synonym :ATM .
-lex:BankAccount a lex:Word ;
+
+lex:BankAccount rdf:type lex:Word ;
     lex:synonym :Account .
-lex:BankCard a lex:Word ;
+
+lex:BankCard rdf:type lex:Word ;
     lex:synonym :CashCard .
-lex:BankCustomer a lex:Word ;
+
+lex:BankCustomer rdf:type lex:Word ;
     lex:synonym :Customer .
-lex:FinancialInstitution a lex:Word ;
+
+lex:FinancialInstitution rdf:type lex:Word ;
     lex:synonym :Bank .
-lex:Person a lex:Word ;
+
+lex:Person rdf:type lex:Word ;
     lex:synonym :Customer .
-lex:WithdrawalTransaction a lex:Word ;
+
+lex:WithdrawalTransaction rdf:type lex:Word ;
     lex:synonym :Withdrawal .
-lex:antonym a rdf:Property ;
+
+lex:antonym rdf:type rdf:Property ;
     rdfs:domain lex:Word ;
     rdfs:range lex:Word .
-lex:synonym a rdf:Property ;
+
+lex:synonym rdf:type rdf:Property ;
     rdfs:domain lex:Word ;
     rdfs:range lex:Word .
-ex:quick a lex:Word ;
+
+ex:quick rdf:type lex:Word ;
     lex:synonym ex:fast .
-ex:slow a lex:Word ;
+
+ex:slow rdf:type lex:Word ;
     lex:antonym ex:fast .
-:ATMRequestVerification a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+<http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .
+
+:ATMRequestVerification rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :requestsVerificationOf ;
             owl:someValuesFrom :Card ] .
-:CardEjected a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:CardEjected rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isResultOf ;
             owl:someValuesFrom :Authorization ] .
-:CreateAccountRecord a owl:ObjectProperty ;
+
+:CreateAccountRecord rdf:type owl:ObjectProperty ;
     rdfs:domain :Account ;
     rdfs:range :AccountRecord .
-:ErrorMessageDisplayed a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:ErrorMessageDisplayed rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isResultOf ;
             owl:someValuesFrom :Authorization ] .
-:NoCashCardInATM a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+:NoCashCardInATM rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:cardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty :hasCashCard ],
         :ShouldDisplayInitialDisplay .
-:RunningOutOfMoney a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+:RunningOutOfMoney rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:allValuesFrom owl:Nothing ;
             owl:onProperty :AcceptsCard ] .
-:TransactionFailure a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:TransactionFailure rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasRequestedAmount ;
-            owl:someValuesFrom [ a owl:Class ;
-                    owl:intersectionOf ( [ a owl:Restriction ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
+                    owl:intersectionOf ( [ rdf:type owl:Restriction ;
                                 owl:hasValue true ;
                                 owl:onProperty :exceedsLimit ] ) ] ],
         :Transaction .
-:TransactionSuccess a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:TransactionSuccess rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
             owl:someValuesFrom :BankComputerSendsSuccessMessage ],
         :Transaction ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:hasValue "succeeded"^^xsd:string ;
             owl:onProperty :hasStatus ] .
-:UpdateLogFile a owl:ObjectProperty ;
+
+:UpdateLogFile rdf:type owl:ObjectProperty ;
     rdfs:domain :LogFile ;
     rdfs:range :LogFile .
-:ValidBankCode a owl:Class ;
+
+:ValidBankCode rdf:type owl:Class ;
     rdfs:subClassOf :BankCode .
-:belongsToBank a owl:ObjectProperty ;
+
+:belongsToBank rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Bank .
-:cardIssuedBy a owl:ObjectProperty ;
+
+:cardIssuedBy rdf:type owl:ObjectProperty ;
     rdfs:domain :CashCard ;
     rdfs:range :Bank .
-:displays a owl:ObjectProperty ;
+
+:displays rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :AmountOfMoney .
-:enters a owl:ObjectProperty ;
+
+:enters rdf:type owl:ObjectProperty ;
     rdfs:domain :Customer ;
     rdfs:range :CashCard .
-:from a owl:ObjectProperty ;
+
+:from rdf:type owl:ObjectProperty ;
     rdfs:domain :Response ;
     rdfs:range :BankComputer .
-:hasAccount a owl:ObjectProperty ;
+
+:hasAccount rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank,
         :Customer ;
     rdfs:range :Account .
-:hasDailyLimit a owl:DatatypeProperty ;
+
+:hasDailyLimit rdf:type owl:DatatypeProperty ;
     rdfs:domain :Account ;
     rdfs:range xsd:decimal .
-:hasEnteredAmount a owl:ObjectProperty ;
+
+:hasEnteredAmount rdf:type owl:ObjectProperty ;
     rdfs:domain :Customer ;
     rdfs:range :Transaction .
-:hasMoney a owl:ObjectProperty ;
+
+:hasMoney rdf:type owl:ObjectProperty ;
     rdfs:domain :Account ;
     rdfs:range :Money .
-:hasMonthlyLimit a owl:DatatypeProperty ;
+
+:hasMonthlyLimit rdf:type owl:DatatypeProperty ;
     rdfs:domain :Account ;
     rdfs:range xsd:decimal .
-:hasProblemWithAccount a owl:ObjectProperty ;
+
+:hasProblemWithAccount rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :ProblemWithAccount .
-:hasRequest a owl:ObjectProperty ;
+
+:hasRequest rdf:type owl:ObjectProperty ;
     rdfs:domain :ProcessTransaction ;
     rdfs:range :TransactionRequest .
-:hasValidPassword a owl:ObjectProperty ;
+
+:hasValidPassword rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :ValidPassword .
-:initializeParameters a owl:ObjectProperty ;
+
+:initializeParameters rdf:type owl:ObjectProperty ;
     rdfs:domain :Parameter ;
     rdfs:range :Parameter .
-:initializedWith a owl:ObjectProperty ;
+
+:initializedWith rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range xsd:decimal .
-:initiates a owl:ObjectProperty ;
+
+:initiates rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :WithdrawalSequence .
-:k a :Parameter ;
+
+:k rdf:type :Parameter ;
     :initializeParameters :t ;
     :setParameters :t .
-:m a :Parameter ;
+
+:m rdf:type :Parameter ;
     :initializeParameters :t ;
     :setParameters :t .
-:n a :Parameter ;
+
+:n rdf:type :Parameter ;
     :initializeParameters :t ;
     :setParameters :t .
-:ownsCard a owl:ObjectProperty ;
+
+:ownsCard rdf:type owl:ObjectProperty ;
     rdfs:domain :Customer ;
     rdfs:range :CashCard .
-:receivesRequest a owl:ObjectProperty ;
+
+:receivesRequest rdf:type owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :processTransaction .
-:returnsBankCode a owl:ObjectProperty ;
+
+:returnsBankCode rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :BankCode .
-:setParameters a owl:ObjectProperty ;
+
+:setParameters rdf:type owl:ObjectProperty ;
     rdfs:domain :Parameter ;
     rdfs:range :Parameter .
-:waitForResponse a owl:ObjectProperty ;
+
+:waitForResponse rdf:type owl:ObjectProperty ;
     rdfs:domain :System ;
     rdfs:range :Response .
-:ATMOperation a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:ATMOperation rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasOutcome ;
             owl:someValuesFrom :DisplayError ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :hasOutcome ;
             owl:someValuesFrom :ReturnCard ] .
-:ATMResponse a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:ATMResponse rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasMoneyDispensed ;
             owl:someValuesFrom :Money ] .
-:AcceptsCard a owl:ObjectProperty ;
+
+:AcceptsCard rdf:type owl:ObjectProperty ;
     rdf:domain :ATM ;
     rdf:range :Card .
-:AccountOK a :Message,
+
+:AccountOK rdf:type :Message,
         owl:NamedIndividual .
-:AccountRecord a owl:Class .
-:AmountOfMoney a owl:Class .
-:AuthorizationDialog a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:AccountRecord rdf:type owl:Class .
+
+:AmountOfMoney rdf:type owl:Class .
+
+:AuthorizationDialog rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :requestsUserToEnter ;
             owl:someValuesFrom :Password ] .
-:BadBankCode a owl:Class .
-:BadPassword a owl:Class .
-:BadPasswordMessage a owl:Class ;
+
+:BadBankCode rdf:type owl:Class .
+
+:BadPassword rdf:type owl:Class .
+
+:BadPasswordMessage rdf:type owl:Class ;
     rdfs:subClassOf :Message .
-:BankComputerSendsSuccessMessage a owl:Class ;
+
+:BankComputerSendsSuccessMessage rdf:type owl:Class ;
     rdfs:subClassOf :BankComputer ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
             owl:someValuesFrom :transactionSucceeded ] .
-:Computer a owl:Class .
-:Dispense a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+:Computer rdf:type owl:Class .
+
+:Dispense rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :after ;
             owl:someValuesFrom :Update ] .
-:Dispensed20DollarBill a owl:Class ;
-    owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( :MoneyDispensed [ a owl:Restriction ;
+
+:Dispensed20DollarBill rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Class ;
+            owl:intersectionOf ( :MoneyDispensed [ rdf:type owl:Restriction ;
                         owl:onProperty :dispenses ;
                         owl:someValuesFrom :MoneyDispensed ] ) ] .
-:InvalidBankCode a owl:Class ;
+
+:InvalidBankCode rdf:type owl:Class ;
     rdfs:subClassOf :BankCode ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:hasValue "bad bank code" ;
             owl:onProperty :hasMessage ] .
-:ProcessTransaction a owl:Class .
-:ShouldDisplayInitialDisplay a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+:ProcessTransaction rdf:type owl:Class .
+
+:ShouldDisplayInitialDisplay rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :display ;
             owl:someValuesFrom :InitialDisplay ] .
-:Software a owl:Class .
-:SuccessfulAuthorization a owl:Class ;
+
+:Software rdf:type owl:Class .
+
+:SuccessfulAuthorization rdf:type owl:Class ;
     rdfs:subClassOf :Authorization .
-:TransactionFailed a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:TransactionFailed rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasStatus ;
             owl:someValuesFrom :Transaction ] .
-:TransactionLimit a owl:Class,
+
+:TransactionLimit rdf:type owl:Class,
         owl:Restriction ;
     owl:onProperty :exceeds ;
     owl:someValuesFrom :Transaction .
-:TransactionRequest a owl:Class .
-:WithdrawalSequence a owl:Class .
-:accepts a owl:ObjectProperty ;
+
+:TransactionRequest rdf:type owl:Class .
+
+:WithdrawalSequence rdf:type owl:Class .
+
+:accepts rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :Withdrawal .
-:after a owl:ObjectProperty ;
+
+:after rdf:type owl:ObjectProperty ;
     rdfs:domain :Dispense ;
     rdfs:range :Update .
-:amount a owl:DatatypeProperty .
-:callBank a rdf:Property ;
+
+:amount rdf:type owl:DatatypeProperty .
+
+:callBank rdf:type rdf:Property ;
     rdfs:label "call bank"@en ;
     rdfs:domain :Customer ;
     rdfs:range :Bank .
-:display a owl:ObjectProperty ;
+
+:display rdf:type owl:ObjectProperty ;
     rdf:domain :ATM ;
     rdf:range :InitialDisplay .
-:displayDuration a owl:DatatypeProperty ;
+
+:displayDuration rdf:type owl:DatatypeProperty ;
     rdfs:domain :ErrorMessage ;
     rdfs:range xsd:integer .
-:displayErrorMessage a owl:ObjectProperty ;
+
+:displayErrorMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :ErrorMessage .
-:displayMessage a rdf:Property ;
+
+:displayMessage rdf:type rdf:Property ;
     rdfs:label "display message"@en ;
     rdfs:domain :Bank ;
     rdfs:range :Message .
-:ejectCard a owl:ObjectProperty ;
+
+:ejectCard rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :Card .
-:exceeds a owl:ObjectProperty ;
+
+:exceeds rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :TransactionLimit .
-:hasBankComputerResponse a owl:ObjectProperty ;
+
+:hasBankComputerResponse rdf:type owl:ObjectProperty ;
     rdfs:domain :Card ;
     rdfs:range :BankComputerResponse .
-:hasCard a owl:ObjectProperty ;
+
+:hasCard rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Card .
-:hasCashCard a owl:ObjectProperty ;
+
+:hasCashCard rdf:type owl:ObjectProperty ;
     rdf:domain :ATM ;
     rdf:range :CashCard .
-:hasErrorMessage a owl:ObjectProperty ;
+
+:hasErrorMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :Card,
         :System ;
     rdfs:range :ErrorMessage .
-:hasItemState a owl:ObjectProperty ;
+
+:hasItemState rdf:type owl:ObjectProperty ;
     rdfs:domain :Item ;
     rdfs:range :StateValue .
-:hasMoneyDispensed a owl:ObjectProperty ;
+
+:hasMoneyDispensed rdf:type owl:ObjectProperty ;
     rdfs:domain :ATMResponse ;
     rdfs:range :Money .
-:hasResponseTime a owl:DatatypeProperty ;
+
+:hasResponseTime rdf:type owl:DatatypeProperty ;
     rdfs:domain :BankComputerResponse ;
     rdfs:range xsd:integer .
-:hasStateValue a owl:ObjectProperty ;
+
+:hasStateValue rdf:type owl:ObjectProperty ;
     rdfs:domain :Function ;
     rdfs:range :StateValue .
-:hasUpdate a owl:ObjectProperty ;
+
+:hasUpdate rdf:type owl:ObjectProperty ;
     rdfs:domain :Account ;
     rdfs:range :Update .
-:hasValidCashCard a owl:ObjectProperty ;
+
+:hasValidCashCard rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :Bank ;
     rdfs:range :CashCard,
         :ValidCashCard .
-:initiated a :StateValue .
-:isCanceled a owl:ObjectProperty ;
+
+:initiated rdf:type :StateValue .
+
+:isCanceled rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :Transaction .
-:isLogged a owl:ObjectProperty ;
+
+:isLogged rdf:type owl:ObjectProperty ;
     rdfs:domain :SerialNumber ;
     rdfs:range :Log .
-:isRestarted a owl:ObjectProperty ;
+
+:isRestarted rdf:type owl:ObjectProperty ;
     rdfs:domain :TransactionDialog ;
     rdfs:range :TransactionDialog .
-:isSuccessful a owl:ObjectProperty ;
+
+:isSuccessful rdf:type owl:ObjectProperty ;
     rdfs:domain :Authorization,
         :Transaction ;
     rdfs:range :SuccessfulAuthorization,
         rdf:Literal .
-:logs a owl:ObjectProperty ;
+
+:logs rdf:type owl:ObjectProperty ;
     rdfs:domain :MoneyDispensed ;
     rdfs:range :AmountLogged .
-:processTransaction a owl:ObjectProperty ;
+
+:processTransaction rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Transaction .
-:processedBy a owl:ObjectProperty ;
+
+:processedBy rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :ATM .
-:readsBankCode a owl:ObjectProperty ;
+
+:readsBankCode rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range xsd:string .
-:readsSerialNumber a owl:ObjectProperty ;
+
+:readsSerialNumber rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range xsd:string .
-:requestsUserToEnter a owl:ObjectProperty ;
+
+:requestsUserToEnter rdf:type owl:ObjectProperty ;
     rdfs:domain :AuthorizationDialog ;
     rdfs:range :Password .
-:sendMessage a owl:ObjectProperty ;
+
+:sendMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :Message .
-:sendsMessage a owl:ObjectProperty ;
+
+:sendsMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank,
         :BankComputer ;
     rdfs:range :ATM,
         :Message .
-:sendsMessageTo a owl:ObjectProperty ;
+
+:sendsMessageTo rdf:type owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :ATM .
-:sendsResponse a owl:ObjectProperty ;
+
+:sendsResponse rdf:type owl:ObjectProperty ;
     rdfs:domain :AmountLogged ;
     rdfs:range :ResponseSent .
-:successful a :StateValue .
-:transactionSucceeded a :Message ;
+
+:successful rdf:type :StateValue .
+
+:transactionSucceeded rdf:type :Message ;
     rdfs:label "transaction succeeded"@en .
-:valid a owl:Class ;
+
+:valid rdf:type owl:Class ;
     rdfs:subClassOf :CashCard .
-:validFor a owl:ObjectProperty ;
+
+:validFor rdf:type owl:ObjectProperty ;
     rdfs:domain :Password ;
     rdfs:range :CashCard .
-ex:fast a lex:Word .
-:BankComputerResponse a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+ex:fast rdf:type lex:Word .
+
+:BankComputerResponse rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:datatype xsd:integer ;
             owl:hasValue 2 ;
             owl:onProperty :hasResponseTime ] .
-:DisplayError a owl:Class .
-:InitialDisplay a owl:Class .
-:InvalidPassword a owl:Class ;
+
+:DisplayError rdf:type owl:Class .
+
+:InitialDisplay rdf:type owl:Class .
+
+:InvalidPassword rdf:type owl:Class ;
     rdfs:subClassOf :Password .
-:Log a owl:Class .
-:LogFile a owl:Class .
-:ProblemWithAccount a owl:Class .
-:Response a owl:Class .
-:ReturnCard a owl:Class .
-:System a owl:Class .
-:WrongPasswordEntry a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:Log rdf:type owl:Class .
+
+:LogFile rdf:type owl:Class .
+
+:ProblemWithAccount rdf:type owl:Class .
+
+:Response rdf:type owl:Class .
+
+:ReturnCard rdf:type owl:Class .
+
+:System rdf:type owl:Class .
+
+:WrongPasswordEntry rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onClass :Card ;
             owl:onProperty :hasWrongPasswordEntry ;
             owl:qualifiedCardinality "3"^^xsd:nonNegativeInteger ] .
-:dispenses a owl:ObjectProperty ;
+
+:dispenses rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :Dispensed20DollarBill ;
     rdfs:range :Money,
         :MoneyDispensed .
-:exceedsLimit a owl:DatatypeProperty ;
+
+:exceedsLimit rdf:type owl:DatatypeProperty ;
     rdfs:range xsd:boolean .
-:hasBankCode a owl:DatatypeProperty,
+
+:hasBankCode rdf:type owl:DatatypeProperty,
         owl:ObjectProperty ;
     rdfs:domain :BankComputer,
         :CashCard ;
     rdfs:range :Bank,
         :BankCode .
-:hasInitialFunctionSequence a owl:ObjectProperty ;
+
+:hasInitialFunctionSequence rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Function .
-:hasMessage a owl:ObjectProperty ;
+
+:hasMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :InvalidBankCode ;
     rdfs:range :Message,
         rdfs:Literal .
-:hasOutcome a owl:ObjectProperty ;
+
+:hasOutcome rdf:type owl:ObjectProperty ;
     rdfs:domain :ATMOperation ;
-    rdfs:range [ a owl:Class ;
+    rdfs:range [ rdf:type owl:Class ;
             owl:unionOf ( :DisplayError :ReturnCard ) ] .
-:hasRequestedAmount a owl:ObjectProperty .
-:hasStatus a owl:DatatypeProperty,
+
+:hasRequestedAmount rdf:type owl:ObjectProperty .
+
+:hasStatus rdf:type owl:DatatypeProperty,
         owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :TransactionFailed,
         xsd:string .
-:hasWrongPasswordEntry a owl:ObjectProperty ;
+
+:hasWrongPasswordEntry rdf:type owl:ObjectProperty ;
     rdfs:domain :Card ;
     rdfs:range :WrongPasswordEntry .
-:isValid a owl:ObjectProperty ;
-    rdfs:domain [ a owl:Class ;
+
+:isValid rdf:type owl:ObjectProperty ;
+    rdfs:domain [ rdf:type owl:Class ;
             owl:unionOf ( :CashCard :Password :Account ) ] ;
     rdfs:range rdf:Literal .
-:providesSecurity a owl:ObjectProperty .
-:receives a owl:ObjectProperty ;
+
+:providesSecurity rdf:type owl:ObjectProperty .
+
+:receives rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :BadAccount .
-:setsItem a owl:ObjectProperty ;
+
+:setsItem rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Item .
-:transaction a :Item .
-:verifies a owl:ObjectProperty ;
+
+:transaction rdf:type :Item .
+
+:verifies rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :Request ;
     rdfs:range :BankComputer,
         :Password .
-:withdrawal a :Function .
-:BadAccount a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:withdrawal rdf:type :Function .
+
+:BadAccount rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
             owl:someValuesFrom :Bank ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :receives ;
             owl:someValuesFrom :ATM ] .
-:Function a owl:Class .
-:Item a owl:Class .
-:Request a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:Function rdf:type owl:Class .
+
+:Item rdf:type owl:Class .
+
+:Request rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :processes ;
             owl:someValuesFrom :Transaction ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :verifies ;
             owl:someValuesFrom :Password ] .
-:ResponseSent a owl:Class .
-:SerialNumber a owl:Class .
-:TransactionDialog a owl:Class,
+
+:ResponseSent rdf:type owl:Class .
+
+:SerialNumber rdf:type owl:Class .
+
+:TransactionDialog rdf:type owl:Class,
         owl:Restriction ;
     owl:onProperty :isRestarted ;
     owl:someValuesFrom :TransactionDialog .
-:Update a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+:Update rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :hasUpdate ;
             owl:someValuesFrom :Account ] .
-:ValidCashCard a owl:Class ;
+
+:ValidCashCard rdf:type owl:Class ;
     rdfs:subClassOf :CashCard .
-:Withdrawal a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:Withdrawal rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :dispenses ;
             owl:someValuesFrom :Money ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :processes ;
             owl:someValuesFrom :Bank ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :accepts ;
             owl:someValuesFrom :Bank ] .
-:checks a owl:ObjectProperty ;
+
+:checks rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :BankComputer ;
     rdfs:range :CashCard,
         :Password .
-:hasSerialNumber a owl:ObjectProperty ;
+
+:hasSerialNumber rdf:type owl:ObjectProperty ;
     rdfs:domain :CashCard ;
     rdfs:range :SerialNumber .
-:processes a owl:ObjectProperty ;
+
+:processes rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :Transaction,
         :Withdrawal .
-:AmountLogged a owl:Class ;
-    owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( :ResponseSent [ a owl:Restriction ;
+
+:AmountLogged rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Class ;
+            owl:intersectionOf ( :ResponseSent [ rdf:type owl:Restriction ;
                         owl:onProperty :sendsResponse ;
                         owl:someValuesFrom :ResponseSent ] ) ] .
-:Authorization a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:Authorization rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :receives ;
             owl:someValuesFrom [ owl:unionOf ( :BadPassword :BadBankCode :BadAccount ) ] ] .
-:MoneyDispensed a owl:Class ;
-    owl:equivalentClass [ a owl:Class ;
-            owl:intersectionOf ( :AmountLogged [ a owl:Restriction ;
+
+:MoneyDispensed rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Class ;
+            owl:intersectionOf ( :AmountLogged [ rdf:type owl:Restriction ;
                         owl:onProperty :logs ;
                         owl:someValuesFrom :AmountLogged ] ) ] .
-:StateValue a owl:Class .
-:hasPassword a owl:DatatypeProperty,
+
+:StateValue rdf:type owl:Class .
+
+:hasPassword rdf:type owl:DatatypeProperty,
         owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :Password .
-:sends a owl:ObjectProperty ;
+
+:sends rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :Bank,
         :BankComputer ;
     rdfs:range :BadAccount,
         :Message,
         :Request .
-:BankCode a owl:Class,
+
+:BankCode rdf:type owl:Class,
         owl:DatatypeProperty ;
-    rdfs:subClassOf [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isValid ;
             owl:someValuesFrom xsd:boolean ] .
-:ErrorMessage a owl:Class ;
+
+:ErrorMessage rdf:type owl:Class ;
     rdfs:label "Error Message"@en ;
     rdfs:comment "An error message is displayed."@en ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:allValuesFrom xsd:integer ;
             owl:hasValue 30 ;
             owl:onProperty :displayDuration ] .
-:Money a owl:Class .
-:Parameter a owl:Class .
-:Card a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:Money rdf:type owl:Class .
+
+:Parameter rdf:type owl:Class .
+
+:Card rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasCard ;
-            owl:someValuesFrom [ a owl:Restriction ;
+            owl:someValuesFrom [ rdf:type owl:Restriction ;
                     owl:onClass :WrongPasswordEntry ;
                     owl:onProperty :hasWrongPasswordEntry ;
                     owl:qualifiedCardinality "3"^^xsd:nonNegativeInteger ] ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :hasSerialNumber ;
             owl:someValuesFrom xsd:string ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :hasPassword ;
             owl:someValuesFrom xsd:string ] ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :hasBankComputerResponse ;
-            owl:someValuesFrom [ a owl:Restriction ;
+            owl:someValuesFrom [ rdf:type owl:Restriction ;
                     owl:onProperty :hasErrorMessage ;
                     owl:someValuesFrom :ErrorMessage ] ] .
-:Account a owl:Class .
-:Password a owl:Class,
+
+:Account rdf:type owl:Class .
+
+:Password rdf:type owl:Class,
         owl:DatatypeProperty ;
-    rdfs:subClassOf [ a owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Class ;
             owl:unionOf ( :ValidPassword :InvalidPassword ) ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :validFor ;
             owl:someValuesFrom :valid ] .
-:BankComputer a owl:Class,
+
+:BankComputer rdf:type owl:Class,
         owl:NamedIndividual ;
-    rdfs:subClassOf [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:allValuesFrom :ATM ;
             owl:onProperty :sendsMessageTo ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :processes ;
             owl:someValuesFrom :Transaction ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :checks ;
             owl:someValuesFrom :BankCode ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :checks ;
             owl:someValuesFrom :Password ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :hasPassword ;
             owl:someValuesFrom :InvalidPassword ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :sendsMessage ;
             owl:someValuesFrom :BadPasswordMessage ] .
-:CashCard a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+:CashCard rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :hasSerialNumber ;
-            owl:someValuesFrom [ a owl:Restriction ;
+            owl:someValuesFrom [ rdf:type owl:Restriction ;
                     owl:onProperty :isLogged ;
                     owl:someValuesFrom :Log ] ] .
-:Transaction a owl:Class,
+
+:Transaction rdf:type owl:Class,
         owl:Restriction ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:onProperty :hasRequestedAmount ;
-            owl:someValuesFrom [ a owl:Class ;
-                    owl:intersectionOf ( [ a owl:Restriction ;
-                                owl:hasValue true ;
-                                owl:onProperty :exceedsLimit ] ) ] ],
-        [ a owl:Restriction ;
-            owl:onProperty :amount ;
-            owl:someValuesFrom xsd:decimal ],
-        [ a owl:Restriction ;
-            owl:onProperty :onAccount ;
-            owl:someValuesFrom :Account ],
-        [ a owl:Restriction ;
-            owl:onProperty :isSuccessful ;
-            owl:someValuesFrom [ a owl:Class ;
-                    owl:complementOf [ a owl:DataRange ;
-                            owl:oneOf ( true ) ] ] ],
-        [ a owl:Restriction ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :displayErrorMessage ;
             owl:someValuesFrom :ErrorMessage ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :ejectCard ;
-            owl:someValuesFrom :Card ] ;
+            owl:someValuesFrom :Card ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :hasRequestedAmount ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
+                    owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                owl:hasValue true ;
+                                owl:onProperty :exceedsLimit ] ) ] ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :amount ;
+            owl:someValuesFrom xsd:decimal ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :onAccount ;
+            owl:someValuesFrom :Account ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :isSuccessful ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
+                    owl:complementOf [ rdf:type owl:DataRange ;
+                            owl:oneOf ( true ) ] ] ] ;
     owl:inverseOf :processedBy ;
     owl:onProperty :isCanceled ;
     owl:someValuesFrom :Transaction .
-:ATM a owl:Class ;
-    rdfs:subClassOf [ a owl:Restriction ;
+
+:ATM rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
             owl:someValuesFrom :Request ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :checks ;
             owl:someValuesFrom :ValidCashCard ],
-        [ a owl:Restriction ;
+        [ rdf:type owl:Restriction ;
             owl:onProperty :verifies ;
-            owl:someValuesFrom [ a owl:Class ;
-                    owl:intersectionOf ( :BankComputer [ a owl:Restriction ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
+                    owl:intersectionOf ( :BankComputer [ rdf:type owl:Restriction ;
                                 owl:onProperty :hasBankCode ;
-                                owl:someValuesFrom rdf:Literal ] [ a owl:Restriction ;
+                                owl:someValuesFrom rdf:Literal ] [ rdf:type owl:Restriction ;
                                 owl:onProperty :hasPassword ;
                                 owl:someValuesFrom rdf:Literal ] ) ] ] .
-[] a owl:Restriction ;
-    owl:someValuesFrom [ a owl:Restriction ] .
-[] a owl:Restriction .
-[] a owl:Class ;
+
+[] rdf:type owl:Restriction ;
+    owl:someValuesFrom [ rdf:type owl:Restriction ] .
+
+[] rdf:type owl:Restriction .
+
+[] rdf:type owl:Class ;
     rdfs:subClassOf :BankComputer ;
-    owl:equivalentClass [ a owl:Restriction ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :sendMessage ;
             owl:someValuesFrom :AccountOK ] ;
-    owl:intersectionOf ( [ a owl:Restriction ;
+    owl:intersectionOf ( [ rdf:type owl:Restriction ;
                 owl:hasValue true ;
                 owl:onProperty :isValid ] ) .
-[] a owl:Restriction .
-[] a owl:Restriction .
-[] a owl:Class ;
-    owl:equivalentClass [ a owl:Restriction ;
+
+[] rdf:type owl:Restriction .
+
+[] rdf:type owl:Restriction .
+
+[] rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :hasValidCashCard ;
-            owl:someValuesFrom [ a owl:Class ;
-                    owl:intersectionOf ( :CashCard [ a owl:Restriction ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
+                    owl:intersectionOf ( :CashCard [ rdf:type owl:Restriction ;
                                 owl:onProperty :readsSerialNumber ;
-                                owl:someValuesFrom xsd:string ] [ a owl:Restriction ;
+                                owl:someValuesFrom xsd:string ] [ rdf:type owl:Restriction ;
                                 owl:onProperty :readsBankCode ;
                                 owl:someValuesFrom xsd:string ] ) ] ] .
-[] a owl:Axiom ;
-    owl:antecedent [ a owl:Restriction ;
+
+[] rdf:type owl:Axiom ;
+    owl:antecedent [ rdf:type owl:Restriction ;
             owl:hasValue :withdrawal ;
             owl:onProperty :hasInitialFunctionSequence ] ;
-    owl:consequent [ a owl:Restriction ;
+    owl:consequent [ rdf:type owl:Restriction ;
             owl:hasValue :successful ;
             owl:onProperty :hasStateValue ] .
-[] a owl:Axiom ;
-    owl:antecedent [ a owl:Restriction ;
+
+[] rdf:type owl:Axiom ;
+    owl:antecedent [ rdf:type owl:Restriction ;
             owl:hasValue :withdrawal ;
             owl:onProperty :hasInitialFunctionSequence ] ;
-    owl:consequent [ a owl:Restriction ;
+    owl:consequent [ rdf:type owl:Restriction ;
             owl:hasValue :transaction ;
             owl:onProperty :setsItem ] .
-[] a owl:Axiom ;
-    owl:antecedent [ a owl:Restriction ;
+
+[] rdf:type owl:Axiom ;
+    owl:antecedent [ rdf:type owl:Restriction ;
             owl:hasValue :transaction ;
             owl:onProperty :setsItem ] ;
-    owl:consequent [ a owl:Restriction ;
+    owl:consequent [ rdf:type owl:Restriction ;
             owl:hasValue :initiated ;
             owl:onProperty :hasItemState ] .
+


### PR DESCRIPTION
## Summary
- Reformat results/combined.ttl with explicit prefix and base declarations and rdf:type keywords to match evaluation ontology style.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baaba897e483308b2544035dccf1d6