### PR TITLE
Ensure consistent Turtle output for Protégé

### DIFF
--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -2,6 +2,8 @@ import logging
 from collections import defaultdict
 from typing import Optional
 
+import re
+
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDF, RDFS, OWL, XSD, Namespace
 from rdflib.plugins.parsers.notation3 import BadSyntax
@@ -30,36 +32,8 @@ class OntologyBuilder:
         self.prefix = prefix if prefix is not None else ""
         self.lexical_namespace = lexical_namespace
         self.graph = Graph()
-        self.graph.bind(self.prefix, self.base_iri)
         # bind common prefixes for consistent header generation
-        self.graph.bind("owl", OWL)
-        self.graph.bind("rdf", RDF)
-        self.graph.bind("xml", Namespace("http://www.w3.org/XML/1998/namespace"))
-        self.graph.bind("xsd", XSD)
-        self.graph.bind("xsp", Namespace("http://www.owl-ontologies.com/2005/08/07/xsp.owl#"))
-        self.graph.bind("rdfs", RDFS)
-        self.graph.bind("swrl", Namespace("http://www.w3.org/2003/11/swrl#"))
-        self.graph.bind("swrlb", Namespace("http://www.w3.org/2003/11/swrlb#"))
-        self.graph.bind("protege", Namespace("http://protege.stanford.edu/plugins/owl/protege#"))
-        initial_ns = {p for p, _ in self.graph.namespaces()}
-
-        ontology_iri = URIRef(self.base_iri.rstrip("#"))
-        self.graph.add((ontology_iri, RDF.type, OWL.Ontology))
-        if ontology_files:
-            for path in ontology_files:
-                self.graph.parse(path)
-        extra = []
-        for p, u in self.graph.namespaces():
-            if p and p not in initial_ns:
-                extra.append((p, str(u)))
-        self.extra_prefixes = extra
-        self._build_header()
-        self._extract_available_terms()
-        self.triple_provenance: dict[str, dict] = {}
-        self._triple_counter = 0
-
-    def _build_header(self):
-        ordered = [
+        self.standard_prefixes = [
             (self.prefix, self.base_iri),
             ("owl", str(OWL)),
             ("rdf", str(RDF)),
@@ -71,9 +45,28 @@ class OntologyBuilder:
             ("swrlb", "http://www.w3.org/2003/11/swrlb#"),
             ("protege", "http://protege.stanford.edu/plugins/owl/protege#"),
         ]
+        for p, u in self.standard_prefixes:
+            self.graph.bind(p, Namespace(u))
+        # capture the allowed prefixes so later saves avoid leaking extra ones
+        self.allowed_prefixes = {p for p, _ in self.graph.namespaces()}
+
+        ontology_iri = URIRef(self.base_iri.rstrip("#"))
+        self.graph.add((ontology_iri, RDF.type, OWL.Ontology))
+        # build the header before parsing external ontologies so only standard
+        # prefixes appear in the output header
+        self._build_header()
+
+        if ontology_files:
+            for path in ontology_files:
+                self.graph.parse(path)
+        self._extract_available_terms()
+        self.triple_provenance: dict[str, dict] = {}
+        self._triple_counter = 0
+
+    def _build_header(self):
         # store prefix and base lines separately so save() can control ordering
         self.prefix_lines = [
-            f"@prefix {p}: <{u}> .\n" for p, u in ordered + self.extra_prefixes
+            f"@prefix {p}: <{u}> .\n" for p, u in self.standard_prefixes
         ]
 
         self.base_line = f"@base <{self.base_iri}> .\n"
@@ -218,7 +211,13 @@ class OntologyBuilder:
     ):
         lines = [line for line in turtle_str.splitlines() if line.strip()]
         cleaned = "\n".join(lines)
-        data = self.header + "\n" + cleaned
+
+        extra_prefix = []
+        for p, u in self.graph.namespaces():
+            if p and p not in self.allowed_prefixes:
+                extra_prefix.append(f"@prefix {p}: <{u}> .\n")
+        parse_header = self.header + "".join(extra_prefix)
+        data = parse_header + "\n" + cleaned
         if logger:
             logger.debug("=== Turtle input to rdflib.parse ===")
             logger.debug(data)
@@ -307,12 +306,25 @@ class OntologyBuilder:
         ontology_iri = URIRef(self.base_iri.rstrip("#"))
         if fmt == "turtle":
             temp = Graph()
-            for pfx, uri in self.graph.namespaces():
-                temp.bind(pfx, uri)
+            for p, u in self.standard_prefixes:
+                temp.bind(p, Namespace(u))
+
+            ignore = [self.lexical_namespace]
+            if self.lexical_namespace.endswith("#"):
+                ignore.append(self.lexical_namespace.rsplit("#", 1)[0] + "/example#")
+
+            def in_ignore(term):
+                return isinstance(term, URIRef) and any(str(term).startswith(ns) for ns in ignore)
+
             for s, p, o in self.graph.triples((None, None, None)):
-                if (s, p, o) != (ontology_iri, RDF.type, OWL.Ontology):
-                    temp.add((s, p, o))
+                if (s, p, o) == (ontology_iri, RDF.type, OWL.Ontology):
+                    continue
+                if in_ignore(s) or in_ignore(p) or in_ignore(o):
+                    continue
+                temp.add((s, p, o))
+
             body = temp.serialize(format="turtle")
+            body = re.sub(r"(?<=\s)a(?=\s)", "rdf:type", body)
             body_lines = [
                 line
                 for line in body.splitlines()

--- a/results/combined.ttl
+++ b/results/combined.ttl
@@ -8,22 +8,13 @@
 @prefix swrl: <http://www.w3.org/2003/11/swrl#> .
 @prefix swrlb: <http://www.w3.org/2003/11/swrlb#> .
 @prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .
-@prefix lex: <http://example.com/lexical#> .
-@prefix ex: <http://example.com/lexical/example#> .
 @base <http://lod.csd.auth.gr/atm/atm.ttl#> .
 
 <http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .
-
-lex:Noun rdf:type rdfs:Class ;
-    rdfs:subClassOf lex:Word .
-
-lex:Word rdf:type rdfs:Class .
-
 :AuthorizationProcess rdf:type rdfs:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :receivesAcceptanceFrom ;
             owl:someValuesFrom :BankComputer ] .
-
 :Bank rdf:type rdfs:Class,
         owl:Class ;
     rdfs:label "Bank"@en ;
@@ -36,14 +27,12 @@ lex:Word rdf:type rdfs:Class .
         [ rdf:type owl:Restriction ;
             owl:onProperty :providesSecurity ;
             owl:someValuesFrom :Software ] .
-
 :Customer rdf:type rdfs:Class,
         owl:Class ;
     rdfs:label "Customer"@en ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :callBank ;
             owl:someValuesFrom :Bank ] .
-
 :Message rdf:type rdfs:Class,
         owl:Class ;
     rdfs:label "Message"@en ;
@@ -54,95 +43,45 @@ lex:Word rdf:type rdfs:Class .
             owl:onProperty :hasMessage ;
             owl:someValuesFrom [ rdf:type owl:Class ;
                     owl:intersectionOf ( :ValidCashCard :ValidPassword :ProblemWithAccount ) ] ] .
-
 :StartTransactionDialog rdf:type rdfs:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isStartedBy ;
             owl:someValuesFrom [ rdf:type owl:Class ;
                     owl:intersectionOf ( :AuthorizationProcess :ValidPassword :ValidSerialNumber ) ] ] .
-
 :ValidPassword rdf:type rdfs:Class,
         owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasPassword ;
             owl:someValuesFrom :Password ],
         :Password .
-
 :ValidSerialNumber rdf:type rdfs:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasSerialNumber ;
             owl:someValuesFrom :SerialNumber ] .
-
-lex:AccountHolder rdf:type lex:Word ;
-    lex:synonym :Customer .
-
-lex:AutomatedTellerMachine rdf:type lex:Word ;
-    lex:synonym :ATM .
-
-lex:BankAccount rdf:type lex:Word ;
-    lex:synonym :Account .
-
-lex:BankCard rdf:type lex:Word ;
-    lex:synonym :CashCard .
-
-lex:BankCustomer rdf:type lex:Word ;
-    lex:synonym :Customer .
-
-lex:FinancialInstitution rdf:type lex:Word ;
-    lex:synonym :Bank .
-
-lex:Person rdf:type lex:Word ;
-    lex:synonym :Customer .
-
-lex:WithdrawalTransaction rdf:type lex:Word ;
-    lex:synonym :Withdrawal .
-
-lex:antonym rdf:type rdf:Property ;
-    rdfs:domain lex:Word ;
-    rdfs:range lex:Word .
-
-lex:synonym rdf:type rdf:Property ;
-    rdfs:domain lex:Word ;
-    rdfs:range lex:Word .
-
-ex:quick rdf:type lex:Word ;
-    lex:synonym ex:fast .
-
-ex:slow rdf:type lex:Word ;
-    lex:antonym ex:fast .
-
-<http://lod.csd.auth.gr/atm/atm.ttl> rdf:type owl:Ontology .
-
 :ATMRequestVerification rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :requestsVerificationOf ;
             owl:someValuesFrom :Card ] .
-
 :CardEjected rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isResultOf ;
             owl:someValuesFrom :Authorization ] .
-
 :CreateAccountRecord rdf:type owl:ObjectProperty ;
     rdfs:domain :Account ;
     rdfs:range :AccountRecord .
-
 :ErrorMessageDisplayed rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isResultOf ;
             owl:someValuesFrom :Authorization ] .
-
 :NoCashCardInATM rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:cardinality "0"^^xsd:nonNegativeInteger ;
             owl:onProperty :hasCashCard ],
         :ShouldDisplayInitialDisplay .
-
 :RunningOutOfMoney rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:allValuesFrom owl:Nothing ;
             owl:onProperty :AcceptsCard ] .
-
 :TransactionFailure rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasRequestedAmount ;
@@ -151,7 +90,6 @@ ex:slow rdf:type lex:Word ;
                                 owl:hasValue true ;
                                 owl:onProperty :exceedsLimit ] ) ] ],
         :Transaction .
-
 :TransactionSuccess rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
@@ -160,111 +98,84 @@ ex:slow rdf:type lex:Word ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:hasValue "succeeded"^^xsd:string ;
             owl:onProperty :hasStatus ] .
-
 :UpdateLogFile rdf:type owl:ObjectProperty ;
     rdfs:domain :LogFile ;
     rdfs:range :LogFile .
-
 :ValidBankCode rdf:type owl:Class ;
     rdfs:subClassOf :BankCode .
-
 :belongsToBank rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Bank .
-
 :cardIssuedBy rdf:type owl:ObjectProperty ;
     rdfs:domain :CashCard ;
     rdfs:range :Bank .
-
 :displays rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :AmountOfMoney .
-
 :enters rdf:type owl:ObjectProperty ;
     rdfs:domain :Customer ;
     rdfs:range :CashCard .
-
 :from rdf:type owl:ObjectProperty ;
     rdfs:domain :Response ;
     rdfs:range :BankComputer .
-
 :hasAccount rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank,
         :Customer ;
     rdfs:range :Account .
-
 :hasDailyLimit rdf:type owl:DatatypeProperty ;
     rdfs:domain :Account ;
     rdfs:range xsd:decimal .
-
 :hasEnteredAmount rdf:type owl:ObjectProperty ;
     rdfs:domain :Customer ;
     rdfs:range :Transaction .
-
 :hasMoney rdf:type owl:ObjectProperty ;
     rdfs:domain :Account ;
     rdfs:range :Money .
-
 :hasMonthlyLimit rdf:type owl:DatatypeProperty ;
     rdfs:domain :Account ;
     rdfs:range xsd:decimal .
-
 :hasProblemWithAccount rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :ProblemWithAccount .
-
 :hasRequest rdf:type owl:ObjectProperty ;
     rdfs:domain :ProcessTransaction ;
     rdfs:range :TransactionRequest .
-
 :hasValidPassword rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :ValidPassword .
-
 :initializeParameters rdf:type owl:ObjectProperty ;
     rdfs:domain :Parameter ;
     rdfs:range :Parameter .
-
 :initializedWith rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range xsd:decimal .
-
 :initiates rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :WithdrawalSequence .
-
 :k rdf:type :Parameter ;
     :initializeParameters :t ;
     :setParameters :t .
-
 :m rdf:type :Parameter ;
     :initializeParameters :t ;
     :setParameters :t .
-
 :n rdf:type :Parameter ;
     :initializeParameters :t ;
     :setParameters :t .
-
 :ownsCard rdf:type owl:ObjectProperty ;
     rdfs:domain :Customer ;
     rdfs:range :CashCard .
-
 :receivesRequest rdf:type owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :processTransaction .
-
 :returnsBankCode rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :BankCode .
-
 :setParameters rdf:type owl:ObjectProperty ;
     rdfs:domain :Parameter ;
     rdfs:range :Parameter .
-
 :waitForResponse rdf:type owl:ObjectProperty ;
     rdfs:domain :System ;
     rdfs:range :Response .
-
 :ATMOperation rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasOutcome ;
@@ -272,381 +183,196 @@ ex:slow rdf:type lex:Word ;
         [ rdf:type owl:Restriction ;
             owl:onProperty :hasOutcome ;
             owl:someValuesFrom :ReturnCard ] .
-
 :ATMResponse rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasMoneyDispensed ;
             owl:someValuesFrom :Money ] .
-
 :AcceptsCard rdf:type owl:ObjectProperty ;
     rdf:domain :ATM ;
     rdf:range :Card .
-
 :AccountOK rdf:type :Message,
         owl:NamedIndividual .
-
 :AccountRecord rdf:type owl:Class .
-
 :AmountOfMoney rdf:type owl:Class .
-
 :AuthorizationDialog rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :requestsUserToEnter ;
             owl:someValuesFrom :Password ] .
-
 :BadBankCode rdf:type owl:Class .
-
 :BadPassword rdf:type owl:Class .
-
 :BadPasswordMessage rdf:type owl:Class ;
     rdfs:subClassOf :Message .
-
 :BankComputerSendsSuccessMessage rdf:type owl:Class ;
     rdfs:subClassOf :BankComputer ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
             owl:someValuesFrom :transactionSucceeded ] .
-
 :Computer rdf:type owl:Class .
-
 :Dispense rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :after ;
             owl:someValuesFrom :Update ] .
-
 :Dispensed20DollarBill rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Class ;
             owl:intersectionOf ( :MoneyDispensed [ rdf:type owl:Restriction ;
                         owl:onProperty :dispenses ;
                         owl:someValuesFrom :MoneyDispensed ] ) ] .
-
 :InvalidBankCode rdf:type owl:Class ;
     rdfs:subClassOf :BankCode ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:hasValue "bad bank code" ;
             owl:onProperty :hasMessage ] .
-
 :ProcessTransaction rdf:type owl:Class .
-
 :ShouldDisplayInitialDisplay rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :display ;
             owl:someValuesFrom :InitialDisplay ] .
-
 :Software rdf:type owl:Class .
-
 :SuccessfulAuthorization rdf:type owl:Class ;
     rdfs:subClassOf :Authorization .
-
 :TransactionFailed rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasStatus ;
             owl:someValuesFrom :Transaction ] .
-
 :TransactionLimit rdf:type owl:Class,
         owl:Restriction ;
     owl:onProperty :exceeds ;
     owl:someValuesFrom :Transaction .
-
 :TransactionRequest rdf:type owl:Class .
-
 :WithdrawalSequence rdf:type owl:Class .
-
 :accepts rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :Withdrawal .
-
 :after rdf:type owl:ObjectProperty ;
     rdfs:domain :Dispense ;
     rdfs:range :Update .
-
 :amount rdf:type owl:DatatypeProperty .
-
 :callBank rdf:type rdf:Property ;
     rdfs:label "call bank"@en ;
     rdfs:domain :Customer ;
     rdfs:range :Bank .
-
 :display rdf:type owl:ObjectProperty ;
     rdf:domain :ATM ;
     rdf:range :InitialDisplay .
-
 :displayDuration rdf:type owl:DatatypeProperty ;
     rdfs:domain :ErrorMessage ;
     rdfs:range xsd:integer .
-
 :displayErrorMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :ErrorMessage .
-
 :displayMessage rdf:type rdf:Property ;
     rdfs:label "display message"@en ;
     rdfs:domain :Bank ;
     rdfs:range :Message .
-
 :ejectCard rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :Card .
-
 :exceeds rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :TransactionLimit .
-
 :hasBankComputerResponse rdf:type owl:ObjectProperty ;
     rdfs:domain :Card ;
     rdfs:range :BankComputerResponse .
-
 :hasCard rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Card .
-
 :hasCashCard rdf:type owl:ObjectProperty ;
     rdf:domain :ATM ;
     rdf:range :CashCard .
-
 :hasErrorMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :Card,
         :System ;
     rdfs:range :ErrorMessage .
-
 :hasItemState rdf:type owl:ObjectProperty ;
     rdfs:domain :Item ;
     rdfs:range :StateValue .
-
 :hasMoneyDispensed rdf:type owl:ObjectProperty ;
     rdfs:domain :ATMResponse ;
     rdfs:range :Money .
-
 :hasResponseTime rdf:type owl:DatatypeProperty ;
     rdfs:domain :BankComputerResponse ;
     rdfs:range xsd:integer .
-
 :hasStateValue rdf:type owl:ObjectProperty ;
     rdfs:domain :Function ;
     rdfs:range :StateValue .
-
 :hasUpdate rdf:type owl:ObjectProperty ;
     rdfs:domain :Account ;
     rdfs:range :Update .
-
 :hasValidCashCard rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :Bank ;
     rdfs:range :CashCard,
         :ValidCashCard .
-
 :initiated rdf:type :StateValue .
-
 :isCanceled rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :Transaction .
-
 :isLogged rdf:type owl:ObjectProperty ;
     rdfs:domain :SerialNumber ;
     rdfs:range :Log .
-
 :isRestarted rdf:type owl:ObjectProperty ;
     rdfs:domain :TransactionDialog ;
     rdfs:range :TransactionDialog .
-
 :isSuccessful rdf:type owl:ObjectProperty ;
     rdfs:domain :Authorization,
         :Transaction ;
     rdfs:range :SuccessfulAuthorization,
         rdf:Literal .
-
 :logs rdf:type owl:ObjectProperty ;
     rdfs:domain :MoneyDispensed ;
     rdfs:range :AmountLogged .
-
 :processTransaction rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range :Transaction .
-
 :processedBy rdf:type owl:ObjectProperty ;
     rdfs:domain :Transaction ;
     rdfs:range :ATM .
-
 :readsBankCode rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range xsd:string .
-
 :readsSerialNumber rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM ;
     rdfs:range xsd:string .
-
 :requestsUserToEnter rdf:type owl:ObjectProperty ;
     rdfs:domain :AuthorizationDialog ;
     rdfs:range :Password .
-
 :sendMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :Message .
-
 :sendsMessage rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank,
         :BankComputer ;
     rdfs:range :ATM,
         :Message .
-
 :sendsMessageTo rdf:type owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :ATM .
-
 :sendsResponse rdf:type owl:ObjectProperty ;
     rdfs:domain :AmountLogged ;
     rdfs:range :ResponseSent .
-
 :successful rdf:type :StateValue .
-
 :transactionSucceeded rdf:type :Message ;
     rdfs:label "transaction succeeded"@en .
-
 :valid rdf:type owl:Class ;
     rdfs:subClassOf :CashCard .
-
 :validFor rdf:type owl:ObjectProperty ;
     rdfs:domain :Password ;
     rdfs:range :CashCard .
-
-ex:fast rdf:type lex:Word .
-
 :BankComputerResponse rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:datatype xsd:integer ;
             owl:hasValue 2 ;
             owl:onProperty :hasResponseTime ] .
-
 :DisplayError rdf:type owl:Class .
-
 :InitialDisplay rdf:type owl:Class .
-
 :InvalidPassword rdf:type owl:Class ;
     rdfs:subClassOf :Password .
-
 :Log rdf:type owl:Class .
-
 :LogFile rdf:type owl:Class .
-
 :ProblemWithAccount rdf:type owl:Class .
-
 :Response rdf:type owl:Class .
-
 :ReturnCard rdf:type owl:Class .
-
 :System rdf:type owl:Class .
-
-:WrongPasswordEntry rdf:type owl:Class ;
-    rdfs:subClassOf [ rdf:type owl:Restriction ;
-            owl:onClass :Card ;
-            owl:onProperty :hasWrongPasswordEntry ;
-            owl:qualifiedCardinality "3"^^xsd:nonNegativeInteger ] .
-
-:dispenses rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATM,
-        :Dispensed20DollarBill ;
-    rdfs:range :Money,
-        :MoneyDispensed .
-
-:exceedsLimit rdf:type owl:DatatypeProperty ;
-    rdfs:range xsd:boolean .
-
-:hasBankCode rdf:type owl:DatatypeProperty,
-        owl:ObjectProperty ;
-    rdfs:domain :BankComputer,
-        :CashCard ;
-    rdfs:range :Bank,
-        :BankCode .
-
-:hasInitialFunctionSequence rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATM ;
-    rdfs:range :Function .
-
-:hasMessage rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATM,
-        :InvalidBankCode ;
-    rdfs:range :Message,
-        rdfs:Literal .
-
-:hasOutcome rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATMOperation ;
-    rdfs:range [ rdf:type owl:Class ;
-            owl:unionOf ( :DisplayError :ReturnCard ) ] .
-
-:hasRequestedAmount rdf:type owl:ObjectProperty .
-
-:hasStatus rdf:type owl:DatatypeProperty,
-        owl:ObjectProperty ;
-    rdfs:domain :Transaction ;
-    rdfs:range :TransactionFailed,
-        xsd:string .
-
-:hasWrongPasswordEntry rdf:type owl:ObjectProperty ;
-    rdfs:domain :Card ;
-    rdfs:range :WrongPasswordEntry .
-
-:isValid rdf:type owl:ObjectProperty ;
-    rdfs:domain [ rdf:type owl:Class ;
-            owl:unionOf ( :CashCard :Password :Account ) ] ;
-    rdfs:range rdf:Literal .
-
-:providesSecurity rdf:type owl:ObjectProperty .
-
-:receives rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATM ;
-    rdfs:range :BadAccount .
-
-:setsItem rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATM ;
-    rdfs:range :Item .
-
-:transaction rdf:type :Item .
-
-:verifies rdf:type owl:ObjectProperty ;
-    rdfs:domain :ATM,
-        :Request ;
-    rdfs:range :BankComputer,
-        :Password .
-
-:withdrawal rdf:type :Function .
-
-:BadAccount rdf:type owl:Class ;
-    rdfs:subClassOf [ rdf:type owl:Restriction ;
-            owl:onProperty :sends ;
-            owl:someValuesFrom :Bank ],
-        [ rdf:type owl:Restriction ;
-            owl:onProperty :receives ;
-            owl:someValuesFrom :ATM ] .
-
-:Function rdf:type owl:Class .
-
-:Item rdf:type owl:Class .
-
-:Request rdf:type owl:Class ;
-    rdfs:subClassOf [ rdf:type owl:Restriction ;
-            owl:onProperty :processes ;
-            owl:someValuesFrom :Transaction ],
-        [ rdf:type owl:Restriction ;
-            owl:onProperty :verifies ;
-            owl:someValuesFrom :Password ] .
-
-:ResponseSent rdf:type owl:Class .
-
-:SerialNumber rdf:type owl:Class .
-
-:TransactionDialog rdf:type owl:Class,
-        owl:Restriction ;
-    owl:onProperty :isRestarted ;
-    owl:someValuesFrom :TransactionDialog .
-
-:Update rdf:type owl:Class ;
-    owl:equivalentClass [ rdf:type owl:Restriction ;
-            owl:onProperty :hasUpdate ;
-            owl:someValuesFrom :Account ] .
-
-:ValidCashCard rdf:type owl:Class ;
-    rdfs:subClassOf :CashCard .
-
 :Withdrawal rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :dispenses ;
@@ -657,46 +383,122 @@ ex:fast rdf:type lex:Word .
         [ rdf:type owl:Restriction ;
             owl:onProperty :accepts ;
             owl:someValuesFrom :Bank ] .
-
+:WrongPasswordEntry rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+            owl:onClass :Card ;
+            owl:onProperty :hasWrongPasswordEntry ;
+            owl:qualifiedCardinality "3"^^xsd:nonNegativeInteger ] .
+:dispenses rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATM,
+        :Dispensed20DollarBill ;
+    rdfs:range :Money,
+        :MoneyDispensed .
+:exceedsLimit rdf:type owl:DatatypeProperty ;
+    rdfs:range xsd:boolean .
+:hasBankCode rdf:type owl:DatatypeProperty,
+        owl:ObjectProperty ;
+    rdfs:domain :BankComputer,
+        :CashCard ;
+    rdfs:range :Bank,
+        :BankCode .
+:hasInitialFunctionSequence rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATM ;
+    rdfs:range :Function .
+:hasMessage rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATM,
+        :InvalidBankCode ;
+    rdfs:range :Message,
+        rdfs:Literal .
+:hasOutcome rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATMOperation ;
+    rdfs:range [ rdf:type owl:Class ;
+            owl:unionOf ( :DisplayError :ReturnCard ) ] .
+:hasRequestedAmount rdf:type owl:ObjectProperty .
+:hasStatus rdf:type owl:DatatypeProperty,
+        owl:ObjectProperty ;
+    rdfs:domain :Transaction ;
+    rdfs:range :TransactionFailed,
+        xsd:string .
+:hasWrongPasswordEntry rdf:type owl:ObjectProperty ;
+    rdfs:domain :Card ;
+    rdfs:range :WrongPasswordEntry .
+:isValid rdf:type owl:ObjectProperty ;
+    rdfs:domain [ rdf:type owl:Class ;
+            owl:unionOf ( :CashCard :Password :Account ) ] ;
+    rdfs:range rdf:Literal .
+:providesSecurity rdf:type owl:ObjectProperty .
+:receives rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATM ;
+    rdfs:range :BadAccount .
+:setsItem rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATM ;
+    rdfs:range :Item .
+:transaction rdf:type :Item .
+:verifies rdf:type owl:ObjectProperty ;
+    rdfs:domain :ATM,
+        :Request ;
+    rdfs:range :BankComputer,
+        :Password .
+:withdrawal rdf:type :Function .
+:BadAccount rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+            owl:onProperty :sends ;
+            owl:someValuesFrom :Bank ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :receives ;
+            owl:someValuesFrom :ATM ] .
+:Function rdf:type owl:Class .
+:Item rdf:type owl:Class .
+:Request rdf:type owl:Class ;
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+            owl:onProperty :processes ;
+            owl:someValuesFrom :Transaction ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :verifies ;
+            owl:someValuesFrom :Password ] .
+:ResponseSent rdf:type owl:Class .
+:SerialNumber rdf:type owl:Class .
+:TransactionDialog rdf:type owl:Class,
+        owl:Restriction ;
+    owl:onProperty :isRestarted ;
+    owl:someValuesFrom :TransactionDialog .
+:Update rdf:type owl:Class ;
+    owl:equivalentClass [ rdf:type owl:Restriction ;
+            owl:onProperty :hasUpdate ;
+            owl:someValuesFrom :Account ] .
+:ValidCashCard rdf:type owl:Class ;
+    rdfs:subClassOf :CashCard .
 :checks rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :BankComputer ;
     rdfs:range :CashCard,
         :Password .
-
 :hasSerialNumber rdf:type owl:ObjectProperty ;
     rdfs:domain :CashCard ;
     rdfs:range :SerialNumber .
-
 :processes rdf:type owl:ObjectProperty ;
     rdfs:domain :Bank ;
     rdfs:range :Transaction,
         :Withdrawal .
-
 :AmountLogged rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Class ;
             owl:intersectionOf ( :ResponseSent [ rdf:type owl:Restriction ;
                         owl:onProperty :sendsResponse ;
                         owl:someValuesFrom :ResponseSent ] ) ] .
-
 :Authorization rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :receives ;
             owl:someValuesFrom [ owl:unionOf ( :BadPassword :BadBankCode :BadAccount ) ] ] .
-
 :MoneyDispensed rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Class ;
             owl:intersectionOf ( :AmountLogged [ rdf:type owl:Restriction ;
                         owl:onProperty :logs ;
                         owl:someValuesFrom :AmountLogged ] ) ] .
-
 :StateValue rdf:type owl:Class .
-
 :hasPassword rdf:type owl:DatatypeProperty,
         owl:ObjectProperty ;
     rdfs:domain :BankComputer ;
     rdfs:range :Password .
-
 :sends rdf:type owl:ObjectProperty ;
     rdfs:domain :ATM,
         :Bank,
@@ -704,13 +506,11 @@ ex:fast rdf:type lex:Word .
     rdfs:range :BadAccount,
         :Message,
         :Request .
-
 :BankCode rdf:type owl:Class,
         owl:DatatypeProperty ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :isValid ;
             owl:someValuesFrom xsd:boolean ] .
-
 :ErrorMessage rdf:type owl:Class ;
     rdfs:label "Error Message"@en ;
     rdfs:comment "An error message is displayed."@en ;
@@ -718,11 +518,9 @@ ex:fast rdf:type lex:Word .
             owl:allValuesFrom xsd:integer ;
             owl:hasValue 30 ;
             owl:onProperty :displayDuration ] .
-
 :Money rdf:type owl:Class .
-
 :Parameter rdf:type owl:Class .
-
+:Account rdf:type owl:Class .
 :Card rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :hasCard ;
@@ -741,9 +539,6 @@ ex:fast rdf:type lex:Word .
             owl:someValuesFrom [ rdf:type owl:Restriction ;
                     owl:onProperty :hasErrorMessage ;
                     owl:someValuesFrom :ErrorMessage ] ] .
-
-:Account rdf:type owl:Class .
-
 :Password rdf:type owl:Class,
         owl:DatatypeProperty ;
     rdfs:subClassOf [ rdf:type owl:Class ;
@@ -751,7 +546,6 @@ ex:fast rdf:type lex:Word .
         [ rdf:type owl:Restriction ;
             owl:onProperty :validFor ;
             owl:someValuesFrom :valid ] .
-
 :BankComputer rdf:type owl:Class,
         owl:NamedIndividual ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -772,17 +566,23 @@ ex:fast rdf:type lex:Word .
         [ rdf:type owl:Restriction ;
             owl:onProperty :sendsMessage ;
             owl:someValuesFrom :BadPasswordMessage ] .
-
 :CashCard rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :hasSerialNumber ;
             owl:someValuesFrom [ rdf:type owl:Restriction ;
                     owl:onProperty :isLogged ;
                     owl:someValuesFrom :Log ] ] .
-
 :Transaction rdf:type owl:Class,
         owl:Restriction ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
+            owl:onProperty :onAccount ;
+            owl:someValuesFrom :Account ],
+        [ rdf:type owl:Restriction ;
+            owl:onProperty :isSuccessful ;
+            owl:someValuesFrom [ rdf:type owl:Class ;
+                    owl:complementOf [ rdf:type owl:DataRange ;
+                            owl:oneOf ( true ) ] ] ],
+        [ rdf:type owl:Restriction ;
             owl:onProperty :displayErrorMessage ;
             owl:someValuesFrom :ErrorMessage ],
         [ rdf:type owl:Restriction ;
@@ -796,19 +596,10 @@ ex:fast rdf:type lex:Word .
                                 owl:onProperty :exceedsLimit ] ) ] ],
         [ rdf:type owl:Restriction ;
             owl:onProperty :amount ;
-            owl:someValuesFrom xsd:decimal ],
-        [ rdf:type owl:Restriction ;
-            owl:onProperty :onAccount ;
-            owl:someValuesFrom :Account ],
-        [ rdf:type owl:Restriction ;
-            owl:onProperty :isSuccessful ;
-            owl:someValuesFrom [ rdf:type owl:Class ;
-                    owl:complementOf [ rdf:type owl:DataRange ;
-                            owl:oneOf ( true ) ] ] ] ;
+            owl:someValuesFrom xsd:decimal ] ;
     owl:inverseOf :processedBy ;
     owl:onProperty :isCanceled ;
     owl:someValuesFrom :Transaction .
-
 :ATM rdf:type owl:Class ;
     rdfs:subClassOf [ rdf:type owl:Restriction ;
             owl:onProperty :sends ;
@@ -824,12 +615,9 @@ ex:fast rdf:type lex:Word .
                                 owl:someValuesFrom rdf:Literal ] [ rdf:type owl:Restriction ;
                                 owl:onProperty :hasPassword ;
                                 owl:someValuesFrom rdf:Literal ] ) ] ] .
-
 [] rdf:type owl:Restriction ;
     owl:someValuesFrom [ rdf:type owl:Restriction ] .
-
 [] rdf:type owl:Restriction .
-
 [] rdf:type owl:Class ;
     rdfs:subClassOf :BankComputer ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
@@ -838,11 +626,8 @@ ex:fast rdf:type lex:Word .
     owl:intersectionOf ( [ rdf:type owl:Restriction ;
                 owl:hasValue true ;
                 owl:onProperty :isValid ] ) .
-
 [] rdf:type owl:Restriction .
-
 [] rdf:type owl:Restriction .
-
 [] rdf:type owl:Class ;
     owl:equivalentClass [ rdf:type owl:Restriction ;
             owl:onProperty :hasValidCashCard ;
@@ -852,7 +637,6 @@ ex:fast rdf:type lex:Word .
                                 owl:someValuesFrom xsd:string ] [ rdf:type owl:Restriction ;
                                 owl:onProperty :readsBankCode ;
                                 owl:someValuesFrom xsd:string ] ) ] ] .
-
 [] rdf:type owl:Axiom ;
     owl:antecedent [ rdf:type owl:Restriction ;
             owl:hasValue :withdrawal ;
@@ -860,7 +644,6 @@ ex:fast rdf:type lex:Word .
     owl:consequent [ rdf:type owl:Restriction ;
             owl:hasValue :successful ;
             owl:onProperty :hasStateValue ] .
-
 [] rdf:type owl:Axiom ;
     owl:antecedent [ rdf:type owl:Restriction ;
             owl:hasValue :withdrawal ;
@@ -868,7 +651,6 @@ ex:fast rdf:type lex:Word .
     owl:consequent [ rdf:type owl:Restriction ;
             owl:hasValue :transaction ;
             owl:onProperty :setsItem ] .
-
 [] rdf:type owl:Axiom ;
     owl:antecedent [ rdf:type owl:Restriction ;
             owl:hasValue :transaction ;
@@ -876,4 +658,3 @@ ex:fast rdf:type lex:Word .
     owl:consequent [ rdf:type owl:Restriction ;
             owl:hasValue :initiated ;
             owl:onProperty :hasItemState ] .
-


### PR DESCRIPTION
## Summary
- Normalize Turtle serialization by expanding `a` to `rdf:type` to match Protégé expectations
- Regenerate `results/combined.ttl` without lexical prefixes and with explicit `rdf:type` statements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baaccb79e483308224d2fc1dd1ed82