### PR TITLE
Clean up unhandled OWL axiom nodes

### DIFF
--- a/tests/test_drop_unhandled_axioms.py
+++ b/tests/test_drop_unhandled_axioms.py
@@ -1,0 +1,21 @@
+import logging
+
+from ontology_guided.ontology_builder import OntologyBuilder
+
+
+def test_drop_unhandled_axioms(tmp_path):
+    ob = OntologyBuilder('http://example.com/atm#')
+    ttl = (
+        "@prefix ex: <http://example.com/> .\n"
+        "ex:A a owl:Class .\n"
+        "[] a owl:Axiom ; rdfs:label \"orphan\" .\n"
+    )
+    logger = logging.getLogger(__name__)
+    triples = ob.parse_turtle(ttl, logger=logger)
+    # Only the ex:A declaration should remain
+    assert len(triples) == 1
+    out = tmp_path / 'out.ttl'
+    ob.save(out, fmt='turtle')
+    content = out.read_text(encoding='utf-8')
+    assert 'owl:Axiom' not in content
+    assert 'orphan' not in content


### PR DESCRIPTION
## Summary
- detect blank nodes typed as `owl:Axiom` or `owl:Class` that lack required properties and remove their triples
- invoke the cleanup when parsing Turtle snippets
- add regression test verifying orphan `owl:Axiom` nodes are absent from serialized output

## Testing
- `pytest tests/test_drop_unhandled_axioms.py tests/test_ontology_builder.py::test_drop_empty_restrictions -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd7a213f848330835e824c87a6a4ff