### PR TITLE
Refine repair prompts and guard ontology consistency

### DIFF
--- a/tests/test_reasoning_quality.py
+++ b/tests/test_reasoning_quality.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 import owlready2
 from ontology_guided.reasoner import run_reasoner, ReasonerError
@@ -77,7 +76,11 @@ def test_reasoning_quality(monkeypatch, tmp_path):
         repair_loop,
         "synthesize_repair_prompts",
         lambda violations, graph, available_terms, inconsistent, max_triples=50: [
-            json.dumps({"offending_axioms": [offending], "violation": "v"})
+            {
+                "prompt": "SYSTEM:\nLOCAL CONTEXT (Turtle):\n\nVIOLATION (canonicalized): v\nSUGGEST PATCH (Turtle only):",
+                "offending_axioms": [offending],
+                "terms": [],
+            }
         ],
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Rework repair prompt synthesis to emit structured system/local context/violation blocks without exposing gold triples while retaining term hints
- Validate each LLM-generated patch with SHACL and apply only if no new violations are introduced
- Update tests for revised prompt format and validation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd90f3c92083309248076c56f56b92