### PR TITLE
Log prompt configuration before test processing

### DIFF
--- a/scripts/save_prompt_config.py
+++ b/scripts/save_prompt_config.py
@@ -1,0 +1,15 @@
+import json
+import os
+from typing import Iterable, Any, Dict
+
+
+def save_prompt_config(prompt_text: str, dev_sentence_ids: Iterable[str], hyperparameters: Dict[str, Any]) -> None:
+    """Persist prompt configuration to results/prompt_config.json."""
+    os.makedirs("results", exist_ok=True)
+    config = {
+        "prompt": prompt_text,
+        "dev_sentence_ids": list(dev_sentence_ids),
+        "hyperparameters": hyperparameters,
+    }
+    with open(os.path.join("results", "prompt_config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- capture dev example IDs alongside system prompt and hyperparameters
- write prompt configuration to `results/prompt_config.json` before test sentences run

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd94782cf08330ba3683f0d0337f3f