### PR TITLE
Handle sentence metadata in JSONL loader

### DIFF
--- a/ontology_guided/data_loader.py
+++ b/ontology_guided/data_loader.py
@@ -40,8 +40,8 @@ class DataLoader:
 
     def load_jsonl_file(
         self, file_path: str, allowed_ids: Optional[Iterable[str]] = None
-    ) -> Iterator[str]:
-        """Yield the ``text`` field from each JSONL line.
+    ) -> Iterator[dict[str, str]]:
+        """Yield ``{"text": ..., "sentence_id": ...}`` for each JSONL record.
 
         When ``allowed_ids`` is provided, only records whose
         ``sentence_id`` is contained in that iterable are returned.
@@ -53,11 +53,11 @@ class DataLoader:
                     data = json.loads(line)
                     sid = str(data.get("sentence_id"))
                     if id_set is None or sid in id_set:
-                        yield data["text"]
+                        yield {"text": data.get("text", ""), "sentence_id": sid}
 
     def load_requirements(
         self, input_paths: List[str], allowed_ids: Optional[Iterable[str]] = None
-    ) -> Iterable[str]:
+    ) -> Iterable[Union[str, dict[str, str]]]:
         id_set = {str(i) for i in allowed_ids} if allowed_ids is not None else None
         for path in input_paths:
             if not os.path.exists(path):

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -38,6 +38,7 @@ def test_compare_metrics(monkeypatch, tmp_path):
 
         buffer = ""
         depth = 0
+        id_set = {str(i) for i in allowed_ids} if allowed_ids is not None else None
         with open(file_path, "r", encoding="utf-8") as f:
             for line in f:
                 stripped = line.strip()
@@ -46,7 +47,10 @@ def test_compare_metrics(monkeypatch, tmp_path):
                 buffer += line
                 depth += line.count("{") - line.count("}")
                 if depth == 0:
-                    yield json.loads(buffer)["text"]
+                    rec = json.loads(buffer)
+                    sid = str(rec.get("sentence_id"))
+                    if id_set is None or sid in id_set:
+                        yield {"text": rec.get("text", ""), "sentence_id": sid}
                     buffer = ""
 
     monkeypatch.setattr(DataLoader, "load_jsonl_file", multiline_jsonl_loader)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -38,8 +38,8 @@ def test_docx_loading_and_preprocessing(tmp_path):
 
 def test_jsonl_loading_and_preprocessing(tmp_path):
     data = [
-        {"text": "* The system shall reboot."},
-        {"text": "1. Users must change password."},
+        {"text": "* The system shall reboot.", "sentence_id": "1"},
+        {"text": "1. Users must change password.", "sentence_id": "2"},
     ]
     file_path = tmp_path / "reqs.jsonl"
     with open(file_path, "w", encoding="utf-8") as f:
@@ -49,11 +49,11 @@ def test_jsonl_loading_and_preprocessing(tmp_path):
 
     loader = DataLoader()
     lines = list(loader.load_requirements([str(file_path)]))
-    assert lines == [obj["text"] for obj in data]
+    assert lines == data
 
     sentences = []
     for line in lines:
-        sentences.extend(loader.preprocess_text(line))
+        sentences.extend(loader.preprocess_text(line["text"]))
     assert sentences == [
         "The system shall reboot.",
         "Users must change password.",
@@ -73,7 +73,7 @@ def test_jsonl_loading_with_allowed_ids(tmp_path):
 
     loader = DataLoader()
     lines = list(loader.load_requirements([str(file_path)], allowed_ids=["2"]))
-    assert lines == ["B"]
+    assert lines == [data[1]]
 
 
 def test_load_requirements_warns_and_raises(tmp_path, caplog):


### PR DESCRIPTION
## Summary
- Return dictionaries with text and sentence_id from JSONL loader
- Accept sentence dictionaries throughout pipeline and extract text for provenance
- Update tests to expect dict-based inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd98d0edc48330aabb4366b2307322