### PR TITLE
Load dev examples automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.jsonl:e
 Το script εκτελεί το pipeline με όλους τους συνδυασμούς των σημαιών `use_terms` και `validate`,
 αποθηκεύοντας τα αποτελέσματα σε πίνακες `table_<N>.csv` και `table_<N>.md` στον φάκελο `evaluation`.
 
-Προαιρετικά, μπορείτε να περάσετε παραδείγματα με `--examples path/to/examples.json`.
+Το script φορτώνει αυτόματα παραδείγματα από το dev split (`splits/dev.txt`).
 
 Η προαιρετική σημαία `--normalize-base` κανονικοποιεί τα base IRIs πριν τη σύγκριση,
 μειώνοντας ψευδείς αποκλίσεις όταν οι ίδιες τριπλέτες χρησιμοποιούν διαφορετικά base.


### PR DESCRIPTION
## Summary
- load dev split few-shot examples and sentence IDs at startup
- ensure test splits do not overlap with dev IDs and restrict processing to test IDs
- update documentation and tests for automatic dev-example handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd99ec6eb08330a89f4f476d8edddb