### PR TITLE
Allow configurable dev example paths

### DIFF
--- a/demo.txt
+++ b/demo.txt
@@ -1,0 +1,1 @@
+The ATM must log all user transactions after card insertion.

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -41,7 +41,9 @@ from .compare_metrics import filter_by_ids
 from ontology_guided.validator import SHACLValidator
 from ontology_guided.reasoner import run_reasoner
 
-DEV_EXAMPLES, DEV_SENTENCE_IDS = load_dev_examples()
+DEV_REQUIREMENTS_PATH = os.path.join(PROJECT_ROOT, "evaluation", "atm_requirements.jsonl")
+DEV_SPLIT_PATH = os.path.join(PROJECT_ROOT, "splits", "dev.txt")
+DEV_EXAMPLES, DEV_SENTENCE_IDS = load_dev_examples(DEV_REQUIREMENTS_PATH, DEV_SPLIT_PATH)
 
 
 Pair = Tuple[str, str, str]


### PR DESCRIPTION
## Summary
- Extend `load_dev_examples` to accept requirement and split paths and return examples with `sentence_id`
- Pass explicit dev example paths in `main` and `evaluation/run_benchmark.py`
- Add missing `demo.txt` sample requirement for tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bda0691ad88330854b8b6dc65230b6