### PR TITLE
Persist retrieval settings in prompt configuration

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -219,7 +219,14 @@ def run_pipeline(
             "temperature": temperature,
             "model": model,
         }
-        save_prompt_config(prompt_text, dev_sentence_ids, hyperparams)
+        save_prompt_config(
+            prompt_text,
+            dev_sentence_ids,
+            hyperparams,
+            use_retrieval=use_retrieval,
+            retrieve_k=retrieve_k,
+            prompt_log=prompt_log,
+        )
 
     snippets_preview = pipeline["owl_snippets"] = []
     BATCH_SIZE = 100

--- a/scripts/save_prompt_config.py
+++ b/scripts/save_prompt_config.py
@@ -1,15 +1,44 @@
 import json
 import os
-from typing import Iterable, Any, Dict
+from pathlib import Path
+from typing import Iterable, Any, Dict, Optional, Union
 
 
-def save_prompt_config(prompt_text: str, dev_sentence_ids: Iterable[str], hyperparameters: Dict[str, Any]) -> None:
-    """Persist prompt configuration to results/prompt_config.json."""
+def save_prompt_config(
+    prompt_text: str,
+    dev_sentence_ids: Iterable[str],
+    hyperparameters: Dict[str, Any],
+    *,
+    use_retrieval: bool = False,
+    retrieve_k: int = 0,
+    prompt_log: Optional[Union[str, Path]] = None,
+) -> None:
+    """Persist prompt configuration to ``results/prompt_config.json``.
+
+    Parameters
+    ----------
+    prompt_text:
+        The prompt text used for generation.
+    dev_sentence_ids:
+        IDs of development sentences used as few-shot examples.
+    hyperparameters:
+        Mapping of additional hyperparameters such as temperature and model.
+    use_retrieval:
+        Whether retrieval-augmented prompting was enabled.
+    retrieve_k:
+        Number of examples retrieved when ``use_retrieval`` is ``True``.
+    prompt_log:
+        Path to the prompt log file produced during generation, if any.
+    """
+
     os.makedirs("results", exist_ok=True)
     config = {
         "prompt": prompt_text,
         "dev_sentence_ids": list(dev_sentence_ids),
         "hyperparameters": hyperparameters,
+        "use_retrieval": use_retrieval,
+        "retrieve_k": retrieve_k,
+        "prompt_log": str(prompt_log) if prompt_log is not None else None,
     }
     with open(os.path.join("results", "prompt_config.json"), "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2, ensure_ascii=False)

--- a/tests/test_save_prompt_config.py
+++ b/tests/test_save_prompt_config.py
@@ -1,0 +1,24 @@
+import json
+
+from scripts.save_prompt_config import save_prompt_config
+
+
+def test_save_prompt_config_includes_retrieval_fields(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    prompt = "demo prompt"
+    dev_ids = ["1", "2"]
+    hyperparams = {"model": "gpt", "temperature": 0.5}
+    log_path = tmp_path / "log.json"
+    save_prompt_config(
+        prompt,
+        dev_ids,
+        hyperparams,
+        use_retrieval=True,
+        retrieve_k=7,
+        prompt_log=log_path,
+    )
+    config_path = tmp_path / "results" / "prompt_config.json"
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["use_retrieval"] is True
+    assert data["retrieve_k"] == 7
+    assert data["prompt_log"].endswith("log.json")


### PR DESCRIPTION
## Summary
- record retrieval flag, retrieved example count, and prompt log path when saving prompt configuration
- ensure run_pipeline forwards retrieval metadata to save_prompt_config
- add regression test for prompt config fields

## Testing
- `OPENAI_API_KEY=dummy pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda55c1ffc8330a00eb61f35cc3f64