### PR TITLE
Use gold TBox as default and strip ABox triples

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,13 @@ python3 evaluation/run_benchmark.py --pairs "evaluation/atm_requirements.jsonl:e
 
 Οι οντολογίες ανά domain καθορίζονται εύκολα μέσω `--ontologies` για
 μεμονωμένα αρχεία ή `--ontology-dir` για φόρτωση όλων των `.ttl` από έναν
-φάκελο. Παράδειγμα:
+φάκελο. Το χρυσό TBox `evaluation/atm_gold.ttl` περιλαμβάνεται εξ ορισμού, αλλά
+όταν χρησιμοποιείται `--ontology-dir` πρέπει να προστίθεται ρητά. Παράδειγμα:
 
 ```bash
 python3 evaluation/run_benchmark.py \
     --pairs "evaluation/atm_requirements.jsonl:evaluation/atm_gold.ttl" \
+    --ontologies evaluation/atm_gold.ttl \
     --ontology-dir ontologies \
     --repeats 1
 ```
@@ -209,7 +211,7 @@ python3 evaluation/run_benchmark.py \
 ```bash
 python -m evaluation.run_benchmark \
     --pairs "evaluation/atm_requirements.jsonl:evaluation/atm_gold.ttl" \
-    --settings '[{"name":"table1","use_terms":true,"validate":true,"ontologies":["ontologies/rbo.ttl","ontologies/lexical.ttl"]}]'
+    --settings '[{"name":"table1","use_terms":true,"validate":true,"ontologies":["evaluation/atm_gold.ttl","ontologies/rbo.ttl","ontologies/lexical.ttl"]}]'
 ```
 
 ### Mini Evaluation Example

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -467,7 +467,7 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         ontology_list.extend(str(p) for p in sorted(dir_path.glob("*.ttl")))
     if not ontology_list:
         ontology_list = [
-            "ontologies/atm_domain.ttl",
+            "evaluation/atm_gold.ttl",
             "ontologies/lexical.ttl",
             "ontologies/lexical_atm.ttl",
         ]

--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -82,6 +82,7 @@ class OntologyBuilder:
         if ontology_files:
             for path in ontology_files:
                 self.graph.parse(path)
+            self._remove_abox_triples()
         self._extract_available_terms()
         self.triple_provenance: dict[str, dict] = {}
         self._triple_counter = 0
@@ -95,6 +96,13 @@ class OntologyBuilder:
         self.base_line = f"@base <{self.base_iri}> .\n"
         # header is used when parsing snippets and expects a blank line after @base
         self.header = "".join(self.prefix_lines + [self.base_line, "\n"])
+
+    def _remove_abox_triples(self):
+        """Drop triples about named individuals to avoid leaking ABox data."""
+        individuals = list(self.graph.subjects(RDF.type, OWL.NamedIndividual))
+        for ind in individuals:
+            self.graph.remove((ind, None, None))
+            self.graph.remove((None, None, ind))
 
     def _extract_available_terms(self):
         nm = self.graph.namespace_manager

--- a/tests/test_ontology_builder.py
+++ b/tests/test_ontology_builder.py
@@ -135,6 +135,27 @@ ex:knownProp a owl:ObjectProperty .
     assert "UnknownClass" in caplog.text
 
 
+def test_strips_named_individuals(tmp_path):
+    ext = tmp_path / "ext.ttl"
+    ext.write_text(
+        """@prefix ex: <http://example.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+ex:A a owl:Class .
+ex:prop a owl:ObjectProperty .
+ex:i a owl:NamedIndividual , ex:A ;
+    ex:prop ex:i .
+""",
+        encoding="utf-8",
+    )
+    ob = OntologyBuilder('http://example.com/base#', ontology_files=[str(ext)])
+    nm = ob.graph.namespace_manager
+    ex_i = nm.expand_curie("ex:i")
+    assert not list(ob.graph.triples((ex_i, None, None)))
+    terms = ob.get_available_terms()
+    assert "ex:i" not in terms["classes"]
+    assert "ex:i" not in terms["properties"]
+
+
 def test_parse_turtle_applies_synonym():
     lex = Path(__file__).resolve().parent.parent / "ontologies" / "lexical.ttl"
     ob = OntologyBuilder('http://example.com/atm#', ontology_files=[str(lex)])


### PR DESCRIPTION
## Summary
- Default benchmark ontologies now include `evaluation/atm_gold.ttl` as the authoritative TBox
- OntologyBuilder strips `owl:NamedIndividual` triples so only class/property IRIs form the vocabulary
- README examples updated to show inclusion of the gold ontology

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda6842d68833080bbcbe3d91ea28f