### PR TITLE
Validate example IDs when retrieval is disabled

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -197,6 +197,17 @@ def run_pipeline(
         logger.info("Using retrieval with %d dev examples", len(dev_pool_data))
         dev_pool = dev_pool_data
 
+    if not use_retrieval and dev_sentence_ids is not None:
+        example_ids = {
+            ex.get("sentence_id")
+            for ex in (examples or [])
+            if ex.get("sentence_id") is not None
+        }
+        if set(dev_sentence_ids) != example_ids:
+            raise RuntimeError(
+                "Example sentence IDs do not match dev_sentence_ids"
+            )
+
     llm = LLMInterface(
         api_key=api_key,
         model=model,


### PR DESCRIPTION
## Summary
- Ensure `run_pipeline` verifies manual example `sentence_id` values against provided `dev_sentence_ids` when retrieval is off
- Raise a RuntimeError early if example IDs and expected dev IDs do not match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdaa0ab6a08330a81c60549fad01c8