### PR TITLE
Cache initial ontology terms and reuse in repair workflow

### DIFF
--- a/ontology_guided/ontology_builder.py
+++ b/ontology_guided/ontology_builder.py
@@ -84,6 +84,14 @@ class OntologyBuilder:
                 self.graph.parse(path)
             self._remove_abox_triples()
         self._extract_available_terms()
+        self.initial_available_terms = {
+            "classes": list(self.available_classes),
+            "properties": list(self.available_properties),
+            "domain_range_hints": {
+                k: v.copy() for k, v in self.domain_range_hints.items()
+            },
+            "synonyms": self.synonym_map.copy(),
+        }
         self.triple_provenance: dict[str, dict] = {}
         self._triple_counter = 0
 
@@ -377,6 +385,7 @@ class OntologyBuilder:
         requirement: Optional[str] = None,
         snippet_index: Optional[int] = None,
         strict_terms: bool = False,
+        update_terms: bool = True,
     ):
         lines = [line for line in turtle_str.splitlines() if line.strip()]
         cleaned = "\n".join(lines)
@@ -473,7 +482,8 @@ class OntologyBuilder:
                     o = nm.expand_curie(syn_map[o_norm])
             self.graph.add((s, p, o))
             canonical_triples.append((s, p, o))
-        self._extract_available_terms()
+        if update_terms:
+            self._extract_available_terms()
         return canonical_triples
 
     def add_provenance(self, requirement: str, triples):

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -165,7 +165,16 @@ def test_run_pipeline_passes_repair_options(monkeypatch, tmp_path):
     captured = {}
 
     class FakeRepairLoop:
-        def __init__(self, data_path, shapes_path, api_key, *, kmax=5, base_iri=None):
+        def __init__(
+            self,
+            data_path,
+            shapes_path,
+            api_key,
+            *,
+            kmax=5,
+            base_iri=None,
+            allowed_terms=None,
+        ):
             captured["kmax"] = kmax
             captured["base_iri"] = base_iri
 
@@ -248,7 +257,16 @@ def test_run_pipeline_skips_repaired_ttl_when_none(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "SHACLValidator", FakeValidator)
 
     class FakeRepairLoop:
-        def __init__(self, data_path, shapes_path, api_key, *, kmax=5, base_iri=None):
+        def __init__(
+            self,
+            data_path,
+            shapes_path,
+            api_key,
+            *,
+            kmax=5,
+            base_iri=None,
+            allowed_terms=None,
+        ):
             pass
 
         def run(self, reason=False, inference="rdfs"):


### PR DESCRIPTION
## Summary
- Snapshot initial ontology terms on builder creation and optionally skip term extraction in `parse_turtle`
- Reuse initial term set in OWL generation and repair loop, passing them to `RepairLoop`
- Allow `RepairLoop` to accept precomputed `allowed_terms` instead of recalculating from data

## Testing
- `pytest tests/test_ontology_builder.py tests/test_run_pipeline.py tests/test_repair_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb33b064083308ce2185226a0b1bf