### PR TITLE
Record retrieval method in prompt configuration

### DIFF
--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -38,6 +38,7 @@ from scripts.main import run_pipeline, load_dev_examples
 from .competency_questions import evaluate_cqs
 from .repair_efficiency import aggregate_repair_efficiency
 from .compare_metrics import filter_by_ids
+from ontology_guided import exemplar_selector
 from ontology_guided.validator import SHACLValidator
 from ontology_guided.reasoner import run_reasoner
 
@@ -123,6 +124,7 @@ def evaluate_once(
         keywords=keywords,
         allowed_ids=test_ids,
         dev_sentence_ids=dev_sentence_ids,
+        retrieval_method=getattr(exemplar_selector, "RETRIEVAL_METHOD", "tfidf_cosine"),
         **settings,
     )
 

--- a/ontology_guided/exemplar_selector.py
+++ b/ontology_guided/exemplar_selector.py
@@ -4,6 +4,8 @@ import math
 from collections import Counter
 from typing import List, Dict, Any
 
+RETRIEVAL_METHOD = "tfidf_cosine"
+
 
 def _tokenize(text: str) -> List[str]:
     """Simple tokenization: lowercase alphanumeric words."""

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -20,6 +20,7 @@ from ontology_guided.llm_interface import LLMInterface
 from ontology_guided.ontology_builder import OntologyBuilder, InvalidTurtleError
 from ontology_guided.validator import SHACLValidator
 from ontology_guided.repair_loop import RepairLoop
+from ontology_guided import exemplar_selector
 from save_prompt_config import save_prompt_config
 
 PROMPT_TEMPLATE = (
@@ -101,6 +102,7 @@ def run_pipeline(
     use_retrieval: bool = False,
     dev_pool: Optional[Union[str, Path, list[dict[str, str]]]] = None,
     retrieve_k: int = 3,
+    retrieval_method: Optional[str] = None,
     prompt_log: Optional[Union[str, Path]] = None,
     repair=False,
     kmax=5,
@@ -240,6 +242,11 @@ def run_pipeline(
         prompt_log=prompt_log,
     )
 
+    if retrieval_method is None and use_retrieval:
+        retrieval_method = getattr(
+            exemplar_selector, "RETRIEVAL_METHOD", "tfidf_cosine"
+        )
+
     # Save prompt configuration once before processing test sentences
     if dev_sentence_ids is not None:
         prompt_messages = llm.build_prompt("", initial_terms, log_examples=False)
@@ -257,6 +264,7 @@ def run_pipeline(
             hyperparams,
             use_retrieval=use_retrieval,
             retrieve_k=retrieve_k,
+            retrieval_method=retrieval_method,
             prompt_log=prompt_log,
         )
 

--- a/scripts/save_prompt_config.py
+++ b/scripts/save_prompt_config.py
@@ -11,6 +11,7 @@ def save_prompt_config(
     *,
     use_retrieval: bool = False,
     retrieve_k: int = 0,
+    retrieval_method: Optional[str] = None,
     prompt_log: Optional[Union[str, Path]] = None,
 ) -> None:
     """Persist prompt configuration to ``results/prompt_config.json``.
@@ -27,6 +28,8 @@ def save_prompt_config(
         Whether retrieval-augmented prompting was enabled.
     retrieve_k:
         Number of examples retrieved when ``use_retrieval`` is ``True``.
+    retrieval_method:
+        Name of the retrieval method used to select examples, if any.
     prompt_log:
         Path to the prompt log file produced during generation, if any.
     """
@@ -38,6 +41,7 @@ def save_prompt_config(
         "hyperparameters": hyperparameters,
         "use_retrieval": use_retrieval,
         "retrieve_k": retrieve_k,
+        "retrieval_method": retrieval_method,
         "prompt_log": str(prompt_log) if prompt_log is not None else None,
     }
     with open(os.path.join("results", "prompt_config.json"), "w", encoding="utf-8") as f:

--- a/tests/test_run_benchmark_cli.py
+++ b/tests/test_run_benchmark_cli.py
@@ -32,6 +32,7 @@ def _run_cli(monkeypatch, tmp_path, extra_args):
             "use_retrieval": kwargs.get("use_retrieval"),
             "dev_pool": kwargs.get("dev_pool"),
             "retrieve_k": kwargs.get("retrieve_k"),
+            "retrieval_method": kwargs.get("retrieval_method"),
             "prompt_log": kwargs.get("prompt_log"),
         }
         return {"combined_ttl": "", "violation_stats": {}, "shacl_conforms": True}
@@ -120,6 +121,7 @@ def test_cli_accepts_retrieval(monkeypatch, tmp_path):
     assert result["retrieval"]["use_retrieval"] is True
     assert result["retrieval"]["dev_pool"] == str(pool)
     assert result["retrieval"]["retrieve_k"] == 4
+    assert result["retrieval"]["retrieval_method"] == "tfidf_cosine"
     assert result["retrieval"]["prompt_log"] == str(log)
 
 

--- a/tests/test_save_prompt_config.py
+++ b/tests/test_save_prompt_config.py
@@ -15,10 +15,12 @@ def test_save_prompt_config_includes_retrieval_fields(tmp_path, monkeypatch):
         hyperparams,
         use_retrieval=True,
         retrieve_k=7,
+        retrieval_method="tfidf_cosine",
         prompt_log=log_path,
     )
     config_path = tmp_path / "results" / "prompt_config.json"
     data = json.loads(config_path.read_text(encoding="utf-8"))
     assert data["use_retrieval"] is True
     assert data["retrieve_k"] == 7
+    assert data["retrieval_method"] == "tfidf_cosine"
     assert data["prompt_log"].endswith("log.json")


### PR DESCRIPTION
## Summary
- track `retrieval_method` in prompt configuration
- propagate retrieval method from pipeline and CLI
- adjust tests for new retrieval metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdbba7867c8330b79e61def720b4c9