### PR TITLE
Refine mini withdrawal iterations and property metadata

### DIFF
--- a/evaluation/mini_pred_iter0.ttl
+++ b/evaluation/mini_pred_iter0.ttl
@@ -1,7 +1,18 @@
 @prefix ex: <http://example.com/mini#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:performedBy rdfs:domain ex:Transaction ;
+  rdfs:range ex:Person .
 
 ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:p1 .
+
+ex:w2 a ex:Withdrawal .
+
+ex:w3 a ex:Withdrawal ;
   ex:performedBy ex:atm1 .
+
+ex:p1 a ex:Person .
 
 ex:atm1 a ex:ATM .

--- a/evaluation/mini_pred_iter1.ttl
+++ b/evaluation/mini_pred_iter1.ttl
@@ -1,8 +1,22 @@
 @prefix ex: <http://example.com/mini#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:performedBy rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:Withdrawal rdfs:subClassOf ex:Transaction .
 
 ex:w1 a ex:Withdrawal ;
-  ex:performedBy ex:atm1 ;
+  ex:performedBy ex:c1 ;
   ex:hasAmount "100"^^xsd:decimal .
+
+ex:w2 a ex:Withdrawal ;
+  ex:hasAmount "50"^^xsd:decimal .
+
+ex:w3 a ex:Withdrawal ;
+  ex:performedBy ex:atm1 .
+
+ex:c1 a ex:Customer .
 
 ex:atm1 a ex:ATM .

--- a/evaluation/mini_pred_iter2.ttl
+++ b/evaluation/mini_pred_iter2.ttl
@@ -1,8 +1,24 @@
 @prefix ex: <http://example.com/mini#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:performedBy rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:Withdrawal rdfs:subClassOf ex:Transaction .
 
 ex:w1 a ex:Withdrawal ;
   ex:performedBy ex:c1 ;
   ex:hasAmount "100"^^xsd:decimal .
 
+ex:w2 a ex:Withdrawal ;
+  ex:performedBy ex:c2 ;
+  ex:hasAmount "50"^^xsd:decimal .
+
+ex:w3 a ex:Withdrawal ;
+  ex:performedBy ex:c3 ;
+  ex:hasAmount "30"^^xsd:decimal .
+
 ex:c1 a ex:Customer .
+ex:c2 a ex:Customer .
+ex:c3 a ex:Customer .


### PR DESCRIPTION
## Summary
- Declare `ex:performedBy` domain `ex:Transaction` and range `ex:Person` and add three `ex:Withdrawal` instances with missing amounts or misused performers
- Introduce `ex:Withdrawal` subclass relation to `ex:Transaction`, change performedBy range to `ex:Customer`, and add/fix amounts and performers across withdrawals
- Finalize withdrawals with `ex:hasAmount` for all and ensure `performedBy` references `ex:Customer` individuals

## Testing
- `python evaluation/mini_example.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be92e74c0c8330bd872c69f9d80a23