### PR TITLE
Add deposit and ATM display competency questions to mini evaluation

### DIFF
--- a/evaluation/mini_cqs.rq
+++ b/evaluation/mini_cqs.rq
@@ -18,3 +18,20 @@ ASK WHERE {
     }
   }
 }
+
+PREFIX ex: <http://example.com/mini#>
+ASK WHERE {
+  FILTER NOT EXISTS {
+    ?d a ex:Deposit ;
+       ex:dispensesCashTo ?c .
+  }
+}
+
+PREFIX ex: <http://example.com/mini#>
+ASK WHERE {
+  FILTER NOT EXISTS {
+    ?atm a ex:ATM .
+    FILTER NOT EXISTS { ?atm ex:hasCard ?card . }
+    FILTER NOT EXISTS { ?atm ex:displays ex:InitialDisplay . }
+  }
+}

--- a/evaluation/mini_gold.ttl
+++ b/evaluation/mini_gold.ttl
@@ -16,8 +16,28 @@ ex:hasAmount a owl:DatatypeProperty ;
   rdfs:domain ex:Transaction ;
   rdfs:range xsd:decimal .
 
+ex:dispensesCashTo a owl:ObjectProperty ;
+  rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:hasCard a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Card .
+
+ex:displays a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Display .
+
+ex:ATM a owl:Class .
+ex:Card a owl:Class .
+ex:Display a owl:Class .
+ex:Deposit rdfs:subClassOf ex:Transaction .
+ex:InitialDisplay a ex:Display .
+
 # Example individuals
 ex:c1 a ex:Customer .
 ex:w1 a ex:Withdrawal ;
   ex:performedBy ex:c1 ;
   ex:hasAmount "100"^^xsd:decimal .
+ex:atm1 a ex:ATM ;
+  ex:displays ex:InitialDisplay .

--- a/evaluation/mini_pred_iter0.ttl
+++ b/evaluation/mini_pred_iter0.ttl
@@ -1,6 +1,7 @@
 @prefix ex: <http://example.com/mini#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 ex:performedBy rdfs:domain ex:Transaction ;
   rdfs:range ex:Person .
@@ -15,4 +16,23 @@ ex:w3 a ex:Withdrawal ;
 
 ex:p1 a ex:Person .
 
-ex:atm1 a ex:ATM .
+ex:atm1 a ex:ATM ;
+  ex:displays ex:InitialDisplay .
+
+ex:dispensesCashTo a owl:ObjectProperty ;
+  rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:hasCard a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Card .
+
+ex:displays a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Display .
+
+ex:ATM a owl:Class .
+ex:Card a owl:Class .
+ex:Display a owl:Class .
+ex:Deposit rdfs:subClassOf ex:Transaction .
+ex:InitialDisplay a ex:Display .

--- a/evaluation/mini_pred_iter1.ttl
+++ b/evaluation/mini_pred_iter1.ttl
@@ -1,6 +1,7 @@
 @prefix ex: <http://example.com/mini#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 ex:performedBy rdfs:domain ex:Transaction ;
   rdfs:range ex:Customer .
@@ -19,4 +20,23 @@ ex:w3 a ex:Withdrawal ;
 
 ex:c1 a ex:Customer .
 
-ex:atm1 a ex:ATM .
+ex:atm1 a ex:ATM ;
+  ex:displays ex:InitialDisplay .
+
+ex:dispensesCashTo a owl:ObjectProperty ;
+  rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:hasCard a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Card .
+
+ex:displays a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Display .
+
+ex:ATM a owl:Class .
+ex:Card a owl:Class .
+ex:Display a owl:Class .
+ex:Deposit rdfs:subClassOf ex:Transaction .
+ex:InitialDisplay a ex:Display .

--- a/evaluation/mini_pred_iter2.ttl
+++ b/evaluation/mini_pred_iter2.ttl
@@ -1,6 +1,7 @@
 @prefix ex: <http://example.com/mini#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 ex:performedBy rdfs:domain ex:Transaction ;
   rdfs:range ex:Customer .
@@ -22,3 +23,24 @@ ex:w3 a ex:Withdrawal ;
 ex:c1 a ex:Customer .
 ex:c2 a ex:Customer .
 ex:c3 a ex:Customer .
+
+ex:atm1 a ex:ATM ;
+  ex:displays ex:InitialDisplay .
+
+ex:dispensesCashTo a owl:ObjectProperty ;
+  rdfs:domain ex:Transaction ;
+  rdfs:range ex:Customer .
+
+ex:hasCard a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Card .
+
+ex:displays a owl:ObjectProperty ;
+  rdfs:domain ex:ATM ;
+  rdfs:range ex:Display .
+
+ex:ATM a owl:Class .
+ex:Card a owl:Class .
+ex:Display a owl:Class .
+ex:Deposit rdfs:subClassOf ex:Transaction .
+ex:InitialDisplay a ex:Display .


### PR DESCRIPTION
## Summary
- extend mini competency queries with deposit cash-dispense and ATM initial display checks
- enrich mini ontology and prediction data with Deposit, ATM display, card classes and properties

## Testing
- `python evaluation/mini_example.py`
- `pytest tests/test_competency_questions.py::test_evaluate_cqs_pass_rate -q`


------
https://chatgpt.com/codex/tasks/task_e_68be93bd90b083309049cd4201704e04