### PR TITLE
Add SHACL example dataset and validation script

### DIFF
--- a/evaluation/shacl_example.py
+++ b/evaluation/shacl_example.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import sys
+
+# Ensure project root is on sys.path when executed directly
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from ontology_guided.validator import SHACLValidator
+
+def main() -> None:
+    base = Path(__file__).resolve().parent
+    shapes_path = base / "mini_shapes.ttl"
+
+    violation_counts = []
+    conform_iter = None
+
+    for idx in range(3):
+        data_path = base / f"shacl_example_iter{idx}.ttl"
+        validator = SHACLValidator(str(data_path), str(shapes_path))
+        conforms, _, summary = validator.run_validation()
+        total = summary.get("total", 0)
+        violation_counts.append(total)
+
+        # collect per-path counts across all shapes
+        path_counts = {}
+        for shape_counts in summary.get("byShapePath", {}).values():
+            for path, count in shape_counts.items():
+                path_counts[path] = path_counts.get(path, 0) + count
+
+        print(f"Iteration {idx}:")
+        for path, count in sorted(path_counts.items()):
+            print(f"  {path}: {count}")
+        print(f"  Total: {total} (conforms={conforms})")
+        if conforms and conform_iter is None:
+            conform_iter = idx
+
+    print("\nViolation counts (pre -> post repair):")
+    for i in range(len(violation_counts) - 1):
+        pre = violation_counts[i]
+        post = violation_counts[i + 1]
+        print(f"Iteration {i}: {pre} -> {post}")
+    if conform_iter is not None:
+        print(f"Conformance achieved at iteration {conform_iter}")
+    else:
+        print("Conformance not achieved")
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/shacl_example_iter0.ttl
+++ b/evaluation/shacl_example_iter0.ttl
@@ -1,0 +1,21 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Individuals
+ex:c1 a ex:Customer .
+ex:e1 a ex:Employee .
+ex:e2 a ex:Employee .
+
+# Withdrawals with violations
+ex:w1 a ex:Withdrawal .
+
+ex:w2 a ex:Withdrawal ;
+  ex:performedBy ex:e1 ;
+  ex:hasAmount "10"^^xsd:string .
+
+ex:w3 a ex:Withdrawal ;
+  ex:performedBy ex:e2 ;
+  ex:hasAmount "30"^^xsd:string .
+
+ex:w4 a ex:Withdrawal ;
+  ex:performedBy ex:c1 .

--- a/evaluation/shacl_example_iter1.ttl
+++ b/evaluation/shacl_example_iter1.ttl
@@ -1,0 +1,23 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Individuals
+ex:c1 a ex:Customer .
+ex:e1 a ex:Employee .
+ex:e2 a ex:Employee .
+
+# Withdrawals after partial repair
+ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:c1 .
+
+ex:w2 a ex:Withdrawal ;
+  ex:performedBy ex:e1 ;
+  ex:hasAmount "10"^^xsd:decimal .
+
+ex:w3 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "30"^^xsd:decimal .
+
+ex:w4 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "40"^^xsd:decimal .

--- a/evaluation/shacl_example_iter2.ttl
+++ b/evaluation/shacl_example_iter2.ttl
@@ -1,0 +1,24 @@
+@prefix ex: <http://example.com/mini#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Individuals
+ex:c1 a ex:Customer .
+ex:e1 a ex:Employee .
+ex:e2 a ex:Employee .
+
+# Withdrawals fully repaired
+ex:w1 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "50"^^xsd:decimal .
+
+ex:w2 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "10"^^xsd:decimal .
+
+ex:w3 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "30"^^xsd:decimal .
+
+ex:w4 a ex:Withdrawal ;
+  ex:performedBy ex:c1 ;
+  ex:hasAmount "40"^^xsd:decimal .


### PR DESCRIPTION
## Summary
- add `shacl_example_iter*.ttl` dataset with 7→2→0 SHACL violations across repairs
- provide `shacl_example.py` script that reports per-path violation counts and conformance iteration

## Testing
- `python evaluation/shacl_example.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be95f3b47483308b9c6718e7aba0b3