### PR TITLE
Add reasoning example demonstrating unsatisfiable classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ The diagram below zooms into the repair cycle from detecting a real violation to
 
    Τα αρχεία που ανεβάζονται διαγράφονται αυτόματα μετά την ολοκλήρωση κάθε αιτήματος.
 
+8. **Παράδειγμα reasoner**
+   ```bash
+   python3 evaluation/reasoning_example.py
+   ```
+   Εκτελεί ένα μικρό παράδειγμα λογικού συμπερασμού· αρχικά εμφανίζει
+   `unsats=1` λόγω ενός εσφαλμένου αξιώματος και μετά την αφαίρεσή του
+   `unsats=0`.
+
 ---
 
 ## 📦 Προ-ενσωματωμένες Οντολογίες

--- a/evaluation/reasoning_example.py
+++ b/evaluation/reasoning_example.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+import os
+from tempfile import NamedTemporaryFile
+import subprocess
+
+# Ensure project root is on sys.path when executed directly
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from rdflib import Graph, Namespace, RDFS
+
+
+def run_unsats(path: str) -> int:
+    code = (
+        "from ontology_guided.reasoner import run_reasoner;import sys;"
+        "u=run_reasoner(sys.argv[1])[2];"
+        "print(len([x for x in u if x != 'http://www.w3.org/2002/07/owl#Nothing']))"
+    )
+    result = subprocess.run([sys.executable, "-c", code, path], capture_output=True, text=True, check=True)
+    return int(result.stdout.strip())
+
+
+def main() -> None:
+    base = Path(__file__).resolve().parent
+    ttl_path = base / "reasoning_example.ttl"
+
+    unsats = run_unsats(str(ttl_path))
+    print(f"unsats={unsats}")
+
+    graph = Graph()
+    graph.parse(ttl_path, format="turtle")
+    ex = Namespace("http://example.com/")
+    graph.remove((ex.VIPCustomer, RDFS.subClassOf, ex.NonCustomer))
+
+    with NamedTemporaryFile("w", suffix=".ttl", delete=False) as tmp:
+        tmp_path = tmp.name
+    try:
+        graph.serialize(destination=tmp_path, format="turtle")
+        unsats = run_unsats(tmp_path)
+        print(f"unsats={unsats}")
+    finally:
+        os.remove(tmp_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/reasoning_example.ttl
+++ b/evaluation/reasoning_example.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.com/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+ex:VIPCustomer rdfs:subClassOf ex:Customer .
+ex:NonCustomer rdfs:subClassOf [ owl:complementOf ex:Customer ] .
+ex:VIPCustomer rdfs:subClassOf ex:NonCustomer .


### PR DESCRIPTION
## Summary
- Add `evaluation/reasoning_example.ttl` with an inconsistency for VIPCustomer
- Provide `evaluation/reasoning_example.py` to run the reasoner before and after fixing the axiom
- Document how to run the example in the README

## Testing
- `python3 evaluation/reasoning_example.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be9709ac788330b45b77be23d6054e