### PR TITLE
Add repair efficiency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ The diagram below zooms into the repair cycle from detecting a real violation to
 4. **Competency Questions** – ποσοστό επιτυχίας σε SPARQL `ASK` queries που εκφράζουν απαιτήσεις του domain.
 5. **Repair Efficiency** – πόσες επαναλήψεις χρειάζονται κατά μέσο όρο για να επιτευχθεί συμμόρφωση.
 
+### Repair efficiency example
+
+Ο φάκελος `evaluation/repair_samples/` περιέχει μικρά JSON αρχεία με
+ενδεικτικά στατιστικά βρόχου επιδιόρθωσης. Εκτελέστε:
+
+```bash
+python3 evaluation/repair_efficiency_example.py
+```
+
+Η έξοδος εμφανίζει την κατανομή των επαναλήψεων μέχρι την πρώτη
+συμμόρφωση και τον μέσο αριθμό επαναλήψεων. Παράδειγμα:
+
+```
+Distribution: {'1': 1, '2': 1, '3': 0, '>3': 1}
+Mean iterations: 3.00
+```
+
 ## 🚀 Γρήγορη Εκκίνηση
 
 1. **Εγκατάσταση βιβλιοθηκών**

--- a/evaluation/repair_efficiency_example.py
+++ b/evaluation/repair_efficiency_example.py
@@ -1,0 +1,35 @@
+"""Example usage of :func:`aggregate_repair_efficiency`.
+
+This script loads sample repair statistics from ``evaluation/repair_samples``
+and prints the distribution of iterations to first conformance together with
+the mean iteration count.  It is intended as a minimal demonstration of how
+repair efficiency metrics can be aggregated across multiple cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+
+# Ensure project root is on ``sys.path`` when executed directly
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from evaluation.repair_efficiency import aggregate_repair_efficiency
+
+
+def main() -> None:
+    base = Path(__file__).resolve().parent / "repair_samples"
+    stats = []
+    for path in sorted(base.glob("*.json")):
+        with path.open("r", encoding="utf8") as fh:
+            stats.append(json.load(fh))
+    efficiency = aggregate_repair_efficiency(stats)
+    print(f"Distribution: {efficiency.distribution}")
+    print(f"Mean iterations: {efficiency.mean_iterations:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/repair_samples/case1.json
+++ b/evaluation/repair_samples/case1.json
@@ -1,0 +1,4 @@
+{
+  "iterations": 1,
+  "first_conforms_iteration": 1
+}

--- a/evaluation/repair_samples/case2.json
+++ b/evaluation/repair_samples/case2.json
@@ -1,0 +1,4 @@
+{
+  "iterations": 3,
+  "first_conforms_iteration": 2
+}

--- a/evaluation/repair_samples/case3.json
+++ b/evaluation/repair_samples/case3.json
@@ -1,0 +1,4 @@
+{
+  "iterations": 5,
+  "first_conforms_iteration": 4
+}


### PR DESCRIPTION
## Summary
- add sample repair-loop metrics in `evaluation/repair_samples`
- demonstrate `aggregate_repair_efficiency` via `repair_efficiency_example.py`
- document sample output in README

## Testing
- `python3 evaluation/repair_efficiency_example.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be980486a48330ab87d0df584f257a