### PR TITLE
feat: load benchmark settings from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,20 @@ python -m evaluation.run_benchmark \
     --settings '[{"name":"table1","use_terms":true,"validate":true,"ontologies":["gold/atm_gold.ttl","ontologies/rbo.ttl","ontologies/lexical.ttl"]}]'
 ```
 
+Εναλλακτικά, οι ρυθμίσεις μπορούν να αποθηκευτούν σε αρχείο JSON και να φορτωθούν με την επιλογή `--settings-file`:
+
+```bash
+python -m evaluation.run_benchmark \
+    --pairs "data/requirements.jsonl:gold/atm_gold.ttl" \
+    --settings-file custom_settings.json
+```
+
+όπου το `custom_settings.json` μπορεί να περιέχει, για παράδειγμα:
+
+```json
+[{"name": "table1", "use_terms": true, "validate": true}]
+```
+
 ### Mini Evaluation Example
 
 Για ένα μίνι παράδειγμα, χρησιμοποιήστε τα αρχεία στον φάκελο `evaluation` που ξεκινούν με `mini_`.

--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -383,6 +383,12 @@ def main() -> None:  # pragma: no cover - CLI wrapper
         help="JSON list with setting dictionaries",
     )
     parser.add_argument(
+        "--settings-file",
+        type=str,
+        default=None,
+        help="Path to JSON file with setting dictionaries",
+    )
+    parser.add_argument(
         "--repeats", type=int, default=1, help="Number of runs per configuration"
     )
     parser.add_argument(
@@ -453,7 +459,9 @@ def main() -> None:  # pragma: no cover - CLI wrapper
 
     pairs = [parse_pair(p) for p in args.pairs]
 
-    if args.settings:
+    if args.settings_file:
+        settings_list = json.load(open(args.settings_file))
+    elif args.settings:
         settings_list = json.loads(args.settings)
     else:
         settings_list = [


### PR DESCRIPTION
## Summary
- allow `evaluation/run_benchmark.py` to read settings from a JSON file via `--settings-file`
- fallback to original `--settings` argument when no file is given
- document settings file usage with CLI example in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beac966d4883308c851e8bbfc03b2e