### PR TITLE
Validate JSON settings in CLI

### DIFF
--- a/evaluation/run_benchmark.py
+++ b/evaluation/run_benchmark.py
@@ -462,7 +462,13 @@ def main() -> None:  # pragma: no cover - CLI wrapper
     if args.settings_file:
         settings_list = json.load(open(args.settings_file))
     elif args.settings:
-        settings_list = json.loads(args.settings)
+        try:
+            settings_list = json.loads(args.settings)
+        except json.JSONDecodeError as exc:
+            raise argparse.ArgumentTypeError(
+                "Invalid JSON for --settings. JSON must be valid; "
+                "for complex configurations, use --settings-file."
+            ) from exc
     else:
         settings_list = [
             {"name": "table1", "use_terms": True, "validate": True},

--- a/tests/test_run_benchmark_cli.py
+++ b/tests/test_run_benchmark_cli.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import argparse
 import pytest
 
 import evaluation.run_benchmark as rb
@@ -144,3 +145,23 @@ def test_cli_rejects_overlap(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", argv)
     with pytest.raises(ValueError):
         rb.main()
+
+
+def test_cli_rejects_invalid_json(monkeypatch, tmp_path):
+    argv = [
+        "run_benchmark.py",
+        "--pairs",
+        "req:gold:shapes",
+        "--settings",
+        "{",
+        "--repeats",
+        "1",
+        "--output-dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(argparse.ArgumentTypeError) as exc_info:
+        rb.main()
+    msg = str(exc_info.value)
+    assert "JSON must be valid" in msg
+    assert "--settings-file" in msg


### PR DESCRIPTION
## Summary
- handle invalid JSON passed via `--settings` by raising `ArgumentTypeError` with guidance to use `--settings-file`
- test CLI rejection of malformed JSON arguments

## Testing
- `pytest tests/test_run_benchmark_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bead9711348330bf8f60176651739f